### PR TITLE
Make MailMessage::getAttribute case-insensitive

### DIFF
--- a/classes/Mail/MailMessage.php
+++ b/classes/Mail/MailMessage.php
@@ -123,11 +123,10 @@ class MailMessage
     private function getAttribute($params, $name)
     {
         foreach ($params as &$obj) {
-            if ($obj->attribute === $name) {
+            if (strcasecmp($obj->attribute, $name) === 0) {
                 return $obj->value;
             }
         }
         return null;
     }
 }
-


### PR DESCRIPTION
I've setup your tool but it wasn't detecting attachments due to the part atrribute names being in uppercase.

The best way for me to make it work was to ensure the attribute names were read anyway, so i've changed it to use strcasecmp instead of the previous comparison