### PR TITLE
Fix Mail::DMARC truncated filename

### DIFF
--- a/classes/Mail/MailMessage.php
+++ b/classes/Mail/MailMessage.php
@@ -105,19 +105,26 @@ class MailMessage
         if ($part->ifdparameters) {
             $filename = $this->getAttribute($part->dparameters, 'filename');
         }
-        if (!$filename && $part->ifparameters) {
-            $filename = $this->getAttribute($part->parameters, 'name');
+
+        // ugly hack to use ifparameters if dparameter is truncated
+        if ($part->ifparameters) {
+            $if_filename = $this->getAttribute($part->parameters, 'name');
+            if (!$filename || strlen($filename) < strlen($if_filename)) {
+                $filename = $if_filename;
+            }
         }
-        if ($filename) {
-            return [
-                'filename' => imap_utf8($filename),
-                'bytes'    => $part->bytes,
-                'number'   => $number,
-                'mnumber'  => $this->number,
-                'encoding' => $part->encoding
-            ];
+
+        if (!$filename) {
+            return null;
         }
-        return null;
+
+        return [
+            'filename' => imap_utf8($filename),
+            'bytes'    => $part->bytes,
+            'number'   => $number,
+            'mnumber'  => $this->number,
+            'encoding' => $part->encoding
+        ];
     }
 
     private function getAttribute($params, $name)

--- a/classes/Mail/MailMessage.php
+++ b/classes/Mail/MailMessage.php
@@ -106,15 +106,11 @@ class MailMessage
             $filename = $this->getAttribute($part->dparameters, 'filename');
         }
 
-        // ugly hack to use ifparameters if dparameter is truncated
-        if ($part->ifparameters) {
-            $if_filename = $this->getAttribute($part->parameters, 'name');
-            if (!$filename || strlen($filename) < strlen($if_filename)) {
-                $filename = $if_filename;
-            }
+        if (empty($filename) && $part->ifparameters) {
+            $filename = $this->getAttribute($part->parameters, 'name');
         }
 
-        if (!$filename) {
+        if (empty($filename)) {
             return null;
         }
 
@@ -129,11 +125,15 @@ class MailMessage
 
     private function getAttribute($params, $name)
     {
+        // need to check all objects as imap_fetchstructure
+        // returns multiple objects with the same attribute name,
+        // but first entry contains a truncated value
+        $value = null;
         foreach ($params as &$obj) {
             if (strcasecmp($obj->attribute, $name) === 0) {
-                return $obj->value;
+                $value = $obj->value;
             }
         }
-        return null;
+        return $value;
     }
 }


### PR DESCRIPTION
Attachment extension check fails if a report is send by Mail::DMARC as the filename gets truncated:

```
Content-Type: application/gzip;
 name=fastmail.com!domain.de!1664582400!1664668799!738011312.xml.gz
Content-Transfer-Encoding: base64
Content-Disposition: inline;
 filename*0=fastmail.com!domain.de!1664582400!1664668799!738011312.xm;
 filename*1=l.gz
```

```
Liuch\DmarcSrg\Mail\MailAttachment Object
(
    [conn:Liuch\DmarcSrg\Mail\MailAttachment:private] => IMAP\Connection Object
        (
        )

    [filename:Liuch\DmarcSrg\Mail\MailAttachment:private] => fastmail.com!domain.de!1657238400!1657324799!686941312.x...
    [bytes:Liuch\DmarcSrg\Mail\MailAttachment:private] => 740
    [number:Liuch\DmarcSrg\Mail\MailAttachment:private] => 2
    [mnumber:Liuch\DmarcSrg\Mail\MailAttachment:private] => 2943
    [encoding] => 3
)
```

```
object(stdClass)#12 (13) {
  ["type"]=>
  int(3)
  ["encoding"]=>
  int(3)
  ["ifsubtype"]=>
  int(1)
  ["subtype"]=>
  string(4) "GZIP"
  ["ifdescription"]=>
  int(0)
  ["ifid"]=>
  int(0)
  ["bytes"]=>
  int(740)
  ["ifdisposition"]=>
  int(1)
  ["disposition"]=>
  string(6) "inline"
  ["ifdparameters"]=>
  int(1)
  ["dparameters"]=>
  array(2) {
    [0]=>
    object(stdClass)#13 (2) {
      ["attribute"]=>
      string(8) "filename"
      ["value"]=>
      string(67) "fastmail.com!domain.de!1657238400!1657324799!686941312.x..."
    }
    [1]=>
    object(stdClass)#14 (2) {
      ["attribute"]=>
      string(8) "filename"
      ["value"]=>
      string(69) "fastmail.com!domain.de!1657238400!1657324799!686941312.xml.gz"
    }
  }
  ["ifparameters"]=>
  int(1)
  ["parameters"]=>
  array(1) {
    [0]=>
    object(stdClass)#15 (2) {
      ["attribute"]=>
      string(4) "name"
      ["value"]=>
      string(69) "fastmail.com!domain.de!1657238400!1657324799!686941312.xml.gz"
    }
  }
}
```

As a hotfix, just check if filename in ifparameters is longer. We probably should fix the `getAttribute` method to always use the last (and complete) element.

Later, I will add a PR to use mime_content_type if PHP fileinfo extension is found to get compression type instead of the file extension of the attachment.