### PR TITLE
Add mime_content_type support

### DIFF
--- a/classes/Mail/MailMessage.php
+++ b/classes/Mail/MailMessage.php
@@ -55,19 +55,22 @@ class MailMessage
         }
     }
 
-    public function isCorrect()
+    public function validate()
     {
         $this->ensureAttachment();
-        if ($this->attachments_cnt === 1) {
-            $bytes = $this->attachment->size();
-            if ($bytes >= 50 && $bytes <= 1 * 1024 * 1024) {
-                $ext = $this->attachment->extension();
-                if ($ext === 'zip' || $ext === 'gz' || $ext === 'xml') {
-                    return true;
-                }
-            }
+        if ($this->attachments_cnt !== 1) {
+            throw new Exception('Attachment count is not valid (' . $this->attachments_cnt . ')');
         }
-        return false;
+
+        $bytes = $this->attachment->size();
+        if ($bytes < 50 || $bytes > 1 * 1024 * 1024) {
+            throw new Exception('Attachment filesize is not valid (' . $bytes . ' bytes)');
+        }
+
+        $mime_type = $this->attachment->mime_type();
+        if (!in_array($mime_type, ['application/zip', 'application/gzip', 'text/xml'])) {
+            throw new Exception('Attachment file type is not valid (' . $mime_type . ')');
+        }
     }
 
     public function attachment()

--- a/classes/ReportFile/ReportFile.php
+++ b/classes/ReportFile/ReportFile.php
@@ -33,16 +33,24 @@ class ReportFile
     private $gzcutfilter = null;
     private $gzinflatefilter = null;
     private static $filters = [];
+    private static $ext_mime_map = [
+        'xml' => 'text/xml',
+        'gz' => 'application/gzip',
+        'zip' => 'application/zip'
+    ];
 
-    private function __construct($filename, $type, $fd)
+    private function __construct($filename, $type = null, $fd = null, $remove = null, $filepath = null)
     {
         $this->filename = $filename;
-        $this->type = $type;
+        $this->type = $type ?? self::get_mime_type($filename, $fd);
+        $this->remove = $remove;
+        $this->filepath = $filepath;
+
         switch ($this->type) {
-            case 'gz':
+            case 'application/gzip':
                 $this->fd = $fd;
                 break;
-            case 'zip':
+            case 'application/zip':
                 if ($fd) {
                     $tmpfname = tempnam(sys_get_temp_dir(), 'dmarc_');
                     if ($tmpfname === false) {
@@ -62,7 +70,7 @@ class ReportFile
     public function __destruct()
     {
         if ($this->fd) {
-            if ($this->type === 'gz' && !$this->filepath) {
+            if ($this->type === 'application/gzip' && !$this->filepath) {
                 $this->enableGzFilter(false);
             }
             gzclose($this->fd);
@@ -75,24 +83,36 @@ class ReportFile
         }
     }
 
+    public static function get_mime_type($filename, $fd = null)
+    {
+        if (function_exists('mime_content_type')) {
+            return mime_content_type($fd ?? $filename);
+        }
+
+        $ext = pathinfo(basename($filename), PATHINFO_EXTENSION);
+        return array_key_exists($ext, self::$ext_mime_map) ?
+            self::$ext_mime_map[$ext] :
+            'application/octet-stream';
+    }
+
     public static function fromFile($filepath, $filename = null, $remove = false)
     {
         if (!is_file($filepath)) {
             throw new \Exception('ReportFile: it is not a file', -1);
         }
-        $fname = $filename ? basename($filename) : basename($filepath);
-        $type = pathinfo($fname, PATHINFO_EXTENSION);
-        $rf = new ReportFile($fname, $type, null);
-        $rf->remove = $remove;
-        $rf->filepath = $filepath;
-        return $rf;
+
+        return new ReportFile(
+            $filename ? basename($filename) : basename($filepath),
+            null,
+            null,
+            $remove,
+            $filepath
+        );
     }
 
-    public static function fromStream($fd, $filename)
+    public static function fromStream($fd, $filename, $type)
     {
-        $type = pathinfo($filename, PATHINFO_EXTENSION);
-        $rf = new ReportFile($filename, $type, $fd);
-        return $rf;
+        return new ReportFile($filename, $type, $fd);
     }
 
     public function filename()
@@ -105,7 +125,7 @@ class ReportFile
         if (!$this->fd) {
             $fd = null;
             switch ($this->type) {
-                case 'zip':
+                case 'application/zip':
                     $this->zip = new \ZipArchive();
                     $this->zip->open($this->filepath);
                     if ($this->zip->count() !== 1) {
@@ -128,7 +148,7 @@ class ReportFile
             }
             $this->fd = $fd;
         }
-        if ($this->type === 'gz' && !$this->filepath) {
+        if ($this->type === 'application/gzip' && !$this->filepath) {
             ReportFile::ensureRegisterFilter(
                 'report_gzfile_cut_filter',
                 'Liuch\DmarcSrg\ReportFile\ReportGZFileCutFilter'

--- a/classes/Sources/MailboxSource.php
+++ b/classes/Sources/MailboxSource.php
@@ -31,6 +31,7 @@
 
 namespace Liuch\DmarcSrg\Sources;
 
+use Exception;
 use Liuch\DmarcSrg\ReportFile\ReportFile;
 
 /**
@@ -50,11 +51,13 @@ class MailboxSource extends Source
     public function current(): object
     {
         $this->msg = $this->data->message($this->list[$this->index]);
-        if (!$this->msg->isCorrect()) {
-            throw new \Exception('Incorrect message', -1);
+        try {
+            $this->msg->validate();
+        } catch(Exception $e) {
+            throw new \Exception('Incorrect message: ' . $e->getMessage(), -1);
         }
         $att = $this->msg->attachment();
-        return ReportFile::fromStream($att->datastream(), $att->filename());
+        return ReportFile::fromStream($att->datastream(), $att->filename(), $att->mime_type());
     }
 
     /**


### PR DESCRIPTION
As some providers don't set the correct extension in filename (filename in attachment was .zip, but file itself was gzip encoded) in report mails I added support for mime_content_type to extract the format of the report if fileinfo/mime_content_type (libmagic) is available.

If the optional extension is not installed, filename extension is still used.

- Add mime_content_type to ReportFile/MailAttachment to check for format of report
- Add caching of mime type
- Add caching of report file until message is processed
- Extend report validation