### PR TITLE
Fix layout

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -212,7 +212,7 @@ textarea.description {
 		display: inline-grid;
 		margin: 0.5em;
 		min-width: 10em;
-        padding: 0.4em;
+		padding: 0.4em;
 		text-align: center;
 		font-size: 0.7em;
 		border: 0.07em solid var(--color-br-strong);
@@ -561,8 +561,8 @@ textarea.description {
 }
 .main-table .report-result {
 	font-size: 75%;
-    width: 3.5em;
-    text-align: center;
+	width: 3.5em;
+	text-align: center;
 }
 .report-result-pass {
 	color: var(--color-st-txtgreen);

--- a/css/main.css
+++ b/css/main.css
@@ -548,6 +548,8 @@ textarea.description {
 	border-radius: 0.4em;
 	padding: 0.2em;
 	margin: 0 0.2em 0 0.2em;
+    width: 3.5em;
+    text-align: center;
 }
 .main-table .report-result {
 	font-size: 75%;

--- a/css/main.css
+++ b/css/main.css
@@ -197,7 +197,7 @@ textarea.description {
 		width: 4em;
 	}
 }
-@media screen and (min-width:46em) {
+@media screen and (min-width:52em) {
 	#stat-block {
 		float: right;
 		margin-bottom: 0.5rem;

--- a/css/main.css
+++ b/css/main.css
@@ -548,11 +548,11 @@ textarea.description {
 	border-radius: 0.4em;
 	padding: 0.2em;
 	margin: 0 0.2em 0 0.2em;
-    width: 3.5em;
-    text-align: center;
 }
 .main-table .report-result {
 	font-size: 75%;
+    width: 3.5em;
+    text-align: center;
 }
 .report-result-pass {
 	color: var(--color-st-txtgreen);

--- a/css/main.css
+++ b/css/main.css
@@ -201,8 +201,8 @@ textarea.description {
 	#stat-block li div {
 		display: inline-grid;
 		margin: 0.5em;
-		width: 6em;
-		height: 6em;
+		min-width: 10em;
+        padding: 0.4em;
 		text-align: center;
 		font-size: 0.7em;
 		border: 0.07em solid var(--color-br-strong);
@@ -214,8 +214,6 @@ textarea.description {
 	}
 	.stat-val {
 		display: block;
-		height: 50%;
-		line-height: 180%;
 		font-size: 1.8em;
 		font-weight: bold;
 	}

--- a/css/main.css
+++ b/css/main.css
@@ -31,6 +31,8 @@
 		--color-nt-warning:  #ff8;
 		--color-nt-inform:   #8f8;
 		--color-sh-default:  rgba(0,0,0,0.5);
+		--color-lk-default:  #0000EE;
+		--color-lk-visited:  #551A8B;
 	}
 }
 @media (prefers-color-scheme: dark) {
@@ -66,6 +68,8 @@
 		--color-nt-warning:  #e7a100;
 		--color-nt-inform:   #3fb950;
 		--color-sh-default:  rgba(255,255,255,0.3);
+		--color-lk-default:  #FFF;
+		--color-lk-visited:  #EEE;
 	}
 }
 
@@ -105,6 +109,12 @@ button:disabled, select:disabled, textarea:disabled, input:disabled {
 }
 textarea, input {
 	background-color: var(--color-bg-input);
+}
+a {
+	color: var(--color-lk-default);
+}
+a:visited {
+	color: var(--color-lk-visited);
 }
 h1 {
 	font-size: 1.4em;

--- a/js/common.js
+++ b/js/common.js
@@ -115,7 +115,7 @@ class Common {
 				if (this.outputMode === "local" || (this.outputMode === "auto" && !prefer_utc)) {
 					return this.toLocaleString();
 				}
-				return this.toUTCString();
+				return this.toLocaleString(undefined, { timeZone: 'UTC', timeZoneName: 'short' });
 			};
 		}
 	}

--- a/js/status.js
+++ b/js/status.js
@@ -99,7 +99,7 @@ class Status {
 		let passed = this._data.emails.dkim_spf_aligned;
 		let forwarded = this._data.emails.dkim_aligned + this._data.emails.spf_aligned;
 		let failed = total - passed - forwarded;
-		this._set_element_data("processed", total === -1 && "?" || total, total !== -1 && "state-blue" || null);
+		this._set_element_data("processed", total === -1 && "?" || total.toLocaleString(), total !== -1 && "state-blue" || null);
 		this._set_element_data("passed", this._formatted_statistic(passed, total), total !== -1 && "state-green" || null);
 		this._set_element_data("forwarded", this._formatted_statistic(forwarded, total), total !== -1 && "state-green" || null);
 		this._set_element_data("failed", this._formatted_statistic(failed, total), total !== -1 && "state-red" || null);


### PR DESCRIPTION
This fixes some layout problems:

- ![grafik](https://user-images.githubusercontent.com/7316652/196054737-8b2d8548-9dfa-4adf-9d08-0974c3a6ab00.png)
  Fixes limited space in header for counters + print count in local format.
- ![grafik](https://user-images.githubusercontent.com/7316652/196054784-b197bd8a-8ada-48cd-9a0d-9e3a2a9d3253.png)
Static size of badges to contains size, regardless if report is marked read or unread.
- ![grafik](https://user-images.githubusercontent.com/7316652/196054838-13ead72a-50f2-4029-bd8c-795e245bf015.png)
Unform format of datetime regardless if localtime or utc is selected.
