### PR TITLE
Show quarantined and rejected numbers

### DIFF
--- a/classes/Database/Mariadb/ReportMapper.php
+++ b/classes/Database/Mariadb/ReportMapper.php
@@ -294,7 +294,6 @@ class ReportMapper implements ReportMapperInterface
                 . $cond_str1 . $order_str . $limit_str
             );
 	    $this->sqlBindValues($st, $f_data, $limit);
-	    //$st->debugDumpParams();
             $st->execute();
             while ($row = $st->fetch(\PDO::FETCH_NUM)) {
                 $list[] = [

--- a/classes/Database/Mariadb/ReportMapper.php
+++ b/classes/Database/Mariadb/ReportMapper.php
@@ -282,7 +282,9 @@ class ReportMapper implements ReportMapperInterface
         try {
             $st = $db->prepare(
                 'SELECT `org`, `begin_time`, `end_time`, `fqdn`, external_id, `seen`, SUM(`rcount`) AS `rcount`,'
-                . ' MIN(`dkim_align`) AS `dkim_align`, MIN(`spf_align`) AS `spf_align`,'
+		. ' MIN(`dkim_align`) AS `dkim_align`, MIN(`spf_align`) AS `spf_align`,'
+		. ' SUM(IF(`disposition` = 0,1,0)) AS `disposition_reject`,'
+		. ' SUM(IF(`disposition` = 1,1,0)) AS `disposition_quarantine`,'
                 . ' MIN(`disposition`) AS `disposition` FROM `' . $this->connector->tablePrefix('rptrecords')
                 . '` AS `rr` RIGHT JOIN (SELECT `rp`.`id`, `org`, `begin_time`, `end_time`, `external_id`,'
                 . ' `fqdn`, `seen` FROM `' . $this->connector->tablePrefix('reports')
@@ -291,7 +293,8 @@ class ReportMapper implements ReportMapperInterface
                 . ') AS `rp` ON `rp`.`id` = `rr`.`report_id` GROUP BY `rp`.`id`'
                 . $cond_str1 . $order_str . $limit_str
             );
-            $this->sqlBindValues($st, $f_data, $limit);
+	    $this->sqlBindValues($st, $f_data, $limit);
+	    //$st->debugDumpParams();
             $st->execute();
             while ($row = $st->fetch(\PDO::FETCH_NUM)) {
                 $list[] = [
@@ -306,7 +309,9 @@ class ReportMapper implements ReportMapperInterface
                     'messages'    => $row[6],
                     'dkim_align'  => Common::$align_res[$row[7]],
                     'spf_align'   => Common::$align_res[$row[8]],
-                    'disposition' => Common::$disposition[$row[9]]
+                    'disposition_reject' => $row[9],
+                    'disposition_quarantine' => $row[10],
+                    'disposition' => Common::$disposition[$row[11]]
                 ];
             }
             $st->closeCursor();
@@ -554,7 +559,7 @@ class ReportMapper implements ReportMapperInterface
      * The valid filter item names
      */
     private static $filters_available = [
-        'domain', 'month', 'before_time', 'organization', 'dkim', 'spf', 'status'
+        'domain', 'month', 'before_time', 'organization', 'dkim', 'spf', 'status', 'disposition'
     ];
 
     /**
@@ -636,6 +641,13 @@ class ReportMapper implements ReportMapperInterface
                                 }
                                 $filters[0]['a_str'][] = '`seen` = ?';
                                 $filters[0]['bindings'][] = [ $val, \PDO::PARAM_BOOL ];
+                            } elseif ($fn == 'disposition') {
+                                $val = array_search($fv, Common::$disposition);
+                                if($val === false) {
+                                    throw new SoftException('Report list filter: Incorrect disposition value');
+                                }
+                                $filters[1]['a_str'][] = '`disposition` <= ?';
+                                $filters[1]['bindings'][] = [ $val, \PDO::PARAM_INT ];
                             }
                         }
                         break;

--- a/classes/Database/Mariadb/ReportMapper.php
+++ b/classes/Database/Mariadb/ReportMapper.php
@@ -282,9 +282,9 @@ class ReportMapper implements ReportMapperInterface
         try {
             $st = $db->prepare(
                 'SELECT `org`, `begin_time`, `end_time`, `fqdn`, external_id, `seen`, SUM(`rcount`) AS `rcount`,'
-		. ' MIN(`dkim_align`) AS `dkim_align`, MIN(`spf_align`) AS `spf_align`,'
-		. ' SUM(IF(`disposition` = 0,1,0)) AS `disposition_reject`,'
-		. ' SUM(IF(`disposition` = 1,1,0)) AS `disposition_quarantine`,'
+                . ' MIN(`dkim_align`) AS `dkim_align`, MIN(`spf_align`) AS `spf_align`,'
+                . ' SUM(IF(`disposition` = 0,1,0)) AS `disposition_reject`,'
+                . ' SUM(IF(`disposition` = 1,1,0)) AS `disposition_quarantine`,'
                 . ' MIN(`disposition`) AS `disposition` FROM `' . $this->connector->tablePrefix('rptrecords')
                 . '` AS `rr` RIGHT JOIN (SELECT `rp`.`id`, `org`, `begin_time`, `end_time`, `external_id`,'
                 . ' `fqdn`, `seen` FROM `' . $this->connector->tablePrefix('reports')
@@ -293,7 +293,7 @@ class ReportMapper implements ReportMapperInterface
                 . ') AS `rp` ON `rp`.`id` = `rr`.`report_id` GROUP BY `rp`.`id`'
                 . $cond_str1 . $order_str . $limit_str
             );
-	    $this->sqlBindValues($st, $f_data, $limit);
+            $this->sqlBindValues($st, $f_data, $limit);
             $st->execute();
             while ($row = $st->fetch(\PDO::FETCH_NUM)) {
                 $list[] = [

--- a/classes/Database/Mariadb/StatisticsMapper.php
+++ b/classes/Database/Mariadb/StatisticsMapper.php
@@ -63,6 +63,8 @@ class StatisticsMapper implements StatisticsMapperInterface
      *                              'dkim_spf_aligned' => Both DKIM and SPF aligned (int)
      *                              'dkim_aligned'     => Only DKIM aligned (int)
      *                              'spf_aligned'      => Only SPF aligned (int)
+     *                              'quarantiend'      => Quarantined (int)
+     *                              'rejected'         => Rejected (int)
      *                          ];
      */
     public function summary($domain, array &$range): array
@@ -73,7 +75,9 @@ class StatisticsMapper implements StatisticsMapperInterface
             $st = $db->prepare(
                 'SELECT SUM(`rcount`), SUM(IF(`dkim_align` = 2 AND `spf_align` = 2, `rcount`, 0)),'
                 . ' SUM(IF(`dkim_align` = 2 AND `spf_align` <> 2, `rcount`, 0)),'
-                . ' SUM(IF(`dkim_align` <> 2 AND `spf_align` = 2, `rcount`, 0))'
+                . ' SUM(IF(`dkim_align` <> 2 AND `spf_align` = 2, `rcount`, 0)),'
+                . ' SUM(IF(`disposition` = 0, `rcount`, 0)),'
+                . ' SUM(IF(`disposition` = 1, `rcount`, 0))'
                 . ' FROM `' . $this->connector->tablePrefix('rptrecords') . '` AS `rr`'
                 . ' INNER JOIN `' . $this->connector->tablePrefix('reports')
                 . '` AS `rp` ON `rr`.`report_id` = `rp`.`id`'
@@ -86,7 +90,9 @@ class StatisticsMapper implements StatisticsMapperInterface
                 'total' => intval($row[0]),
                 'dkim_spf_aligned' => intval($row[1]),
                 'dkim_aligned' => intval($row[2]),
-                'spf_aligned' => intval($row[3])
+                'spf_aligned' => intval($row[3]),
+                'rejected' => intval($row[4]),
+                'quarantined' => intval($row[5])
             ];
             $st->closeCursor();
 

--- a/classes/Database/Mariadb/StatisticsMapper.php
+++ b/classes/Database/Mariadb/StatisticsMapper.php
@@ -89,10 +89,10 @@ class StatisticsMapper implements StatisticsMapperInterface
             $ems = [
                 'total' => intval($row[0]),
                 'dkim_spf_aligned' => intval($row[1]),
-                'dkim_aligned' => intval($row[2]),
-                'spf_aligned' => intval($row[3]),
-                'rejected' => intval($row[4]),
-                'quarantined' => intval($row[5])
+                'dkim_aligned'     => intval($row[2]),
+                'spf_aligned'      => intval($row[3]),
+                'rejected'         => intval($row[4]),
+                'quarantined'      => intval($row[5])
             ];
             $st->closeCursor();
 
@@ -127,7 +127,9 @@ class StatisticsMapper implements StatisticsMapperInterface
         try {
             $st = $this->connector->dbh()->prepare(
                 'SELECT `ip`, SUM(`rcount`) AS `rcount`, SUM(IF(`dkim_align` = 2, `rcount`, 0)) AS `dkim_aligned`,'
-                . ' SUM(IF(`spf_align` = 2, `rcount`, 0)) AS `spf_aligned`'
+                . ' SUM(IF(`spf_align` = 2, `rcount`, 0)) AS `spf_aligned`,'
+                . ' SUM(IF(`disposition` = 0, `rcount`, 0)),'
+                . ' SUM(IF(`disposition` = 1, `rcount`, 0))'
                 . ' FROM `' . $this->connector->tablePrefix('rptrecords') . '` AS `rr`'
                 . ' INNER JOIN `' . $this->connector->tablePrefix('reports')
                 . '` AS `rp` ON `rr`.`report_id` = `rp`.`id`'
@@ -141,7 +143,9 @@ class StatisticsMapper implements StatisticsMapperInterface
                     'ip'           => inet_ntop($row[0]),
                     'emails'       => intval($row[1]),
                     'dkim_aligned' => intval($row[2]),
-                    'spf_aligned'  => intval($row[3])
+                    'spf_aligned'  => intval($row[3]),
+                    'rejected'     => intval($row[4]),
+                    'quarantined'  => intval($row[5])
                 ];
             }
             $st->closeCursor();

--- a/classes/Database/StatisticsMapperInterface.php
+++ b/classes/Database/StatisticsMapperInterface.php
@@ -45,6 +45,8 @@ interface StatisticsMapperInterface
      *                              'dkim_spf_aligned' => Both DKIM and SPF aligned (int)
      *                              'dkim_aligned'     => Only DKIM aligned (int)
      *                              'spf_aligned'      => Only SPF aligned (int)
+     *                              'quarantined'      => Quarantined (int)
+     *                              'rejected'         => Rejected (int)
      *                          ];
      */
     public function summary($domain, array &$range): array;

--- a/classes/Report/ReportList.php
+++ b/classes/Report/ReportList.php
@@ -206,8 +206,8 @@ class ReportList
             'month'        => $reportMapper->months(),
             'organization' => $reportMapper->organizations(),
             'dkim'         => [ 'pass', 'fail' ],
-	    'spf'          => [ 'pass', 'fail' ],
-	    'disposition'  => Common::$disposition,
+            'spf'          => [ 'pass', 'fail' ],
+            'disposition'  => Common::$disposition,
             'status'       => [ 'read', 'unread' ]
         ];
     }

--- a/classes/Report/ReportList.php
+++ b/classes/Report/ReportList.php
@@ -32,6 +32,7 @@
 namespace Liuch\DmarcSrg\Report;
 
 use Liuch\DmarcSrg\Core;
+use Liuch\DmarcSrg\Common;
 
 /**
  * It's the main class for working with the incoming reports, such as:
@@ -205,7 +206,8 @@ class ReportList
             'month'        => $reportMapper->months(),
             'organization' => $reportMapper->organizations(),
             'dkim'         => [ 'pass', 'fail' ],
-            'spf'          => [ 'pass', 'fail' ],
+	    'spf'          => [ 'pass', 'fail' ],
+	    'disposition'  => Common::$disposition,
             'status'       => [ 'read', 'unread' ]
         ];
     }

--- a/classes/Report/SummaryReport.php
+++ b/classes/Report/SummaryReport.php
@@ -180,9 +180,9 @@ class SummaryReport
                     $it['ip'],
                     $total,
                     $spf_str,
-		    $dkim_str,
-		    $qua_str,
-		    $rej_str
+                    $dkim_str,
+                    $qua_str,
+                    $rej_str
                 );
             }
             unset($it);
@@ -283,8 +283,8 @@ class SummaryReport
             $style = "style=\"{$d2s}{$d3s}{$d5s}\"";
             $res[] = "  <tr><th {$style}>pass</th><th {$style}>fail</th><th {$style}>rate</th>" .
                      "<th {$style}>pass</th><th {$style}>fail</th><th {$style}>rate</th>".
-		     "<th {$style}>qurantined</th><th {$style}>rate</th>".
-		     "<th {$style}>rejected</th><th {$style}>rate</th></tr>";
+                     "<th {$style}>qurantined</th><th {$style}>rate</th>".
+                     "<th {$style}>rejected</th><th {$style}>rate</th></tr>";
             $res[] = ' </thead>';
             $res[] = ' <tbody>';
             foreach ($rdata['sources'] as &$row) {
@@ -296,10 +296,10 @@ class SummaryReport
                 $dkim_a = $row['dkim_aligned'];
                 $dkim_n = $total - $dkim_a;
                 $dkim_p = sprintf('%.0f%%', $dkim_a / $total * 100);
-		$qua_a  = $row['quarantined'];
-		$qua_p  = sprintf('%.0f%%', $qua_a / $total * 100);
-		$rej_a  = $row['rejected'];
-		$rej_p  = sprintf('%.0f%%', $rej_a / $total * 100);
+                $qua_a  = $row['quarantined'];
+                $qua_p  = sprintf('%.0f%%', $qua_a / $total * 100);
+                $rej_a  = $row['rejected'];
+                $rej_p  = sprintf('%.0f%%', $rej_a / $total * 100);
                 $style  = "style=\"{$d3s}{$d5s}";
 
                 $row_str  = "  <tr><td {$style}\">{$ip}</td><td {$style}{$d4s}\">{$total}</td>";
@@ -307,7 +307,7 @@ class SummaryReport
                 $row_str .= "<td {$style}{$d4s}{$add_orange($spf_n)}\">{$spf_n}</td>";
                 $row_str .= "<td {$style}{$d4s}\">{$spf_p}</td>";
                 $row_str .= "<td {$style}{$d4s}{$add_green($dkim_a)}\">{$dkim_a}</td>";
-		$row_str .= "<td {$style}{$d4s}{$add_orange($dkim_n)}\">{$dkim_n}</td>";
+                $row_str .= "<td {$style}{$d4s}{$add_orange($dkim_n)}\">{$dkim_n}</td>";
                 $row_str .= "<td {$style}{$d4s}\">{$dkim_p}</td>";
                 $row_str .= "<td {$style}{$d4s}{$add_orange($qua_a)}\">{$qua_a}</td>";
                 $row_str .= "<td {$style}{$d4s}\">{$qua_p}</td>";
@@ -408,18 +408,18 @@ class SummaryReport
         $aligned   = $summ['emails']['dkim_spf_aligned'] +
                      $summ['emails']['dkim_aligned'] +
                      $summ['emails']['spf_aligned'];
-	$n_aligned = $total - $aligned;
-	$rejected  = $summ['emails']['rejected'];
-	$quarantined = $summ['emails']['quarantined'];
+        $n_aligned = $total - $aligned;
+        $rejected  = $summ['emails']['rejected'];
+        $quarantined = $summ['emails']['quarantined'];
 
         $rdata['summary'] = [
             'total'         => $total,
             'organizations' => $summ['organizations']
         ];
 
-	$rdata['summary']['aligned']     = $aligned;
+        $rdata['summary']['aligned']     = $aligned;
         $rdata['summary']['quarantined'] = $quarantined;
-	$rdata['summary']['rejected']    = $rejected;
+        $rdata['summary']['rejected']    = $rejected;
 
         if ($total > 0) {
             $rdata['summary']['n_aligned'] = $n_aligned;

--- a/classes/Report/SummaryReport.php
+++ b/classes/Report/SummaryReport.php
@@ -149,30 +149,40 @@ class SummaryReport
         $res[] = sprintf(' Total: %d', $total);
         $res[] = sprintf(' DKIM or SPF aligned: %s', self::num2percent($rdata['summary']['aligned'], $total));
         $res[] = sprintf(' Not aligned: %s', self::num2percent($rdata['summary']['n_aligned'], $total));
+        $res[] = sprintf(' Quarantined: %s', self::num2percent($rdata['summary']['quarantined'], $total));
+        $res[] = sprintf(' Rejected: %s', self::num2percent($rdata['summary']['rejected'], $total));
         $res[] = sprintf(' Organizations: %d', $rdata['summary']['organizations']);
         $res[] = '';
 
         if (count($rdata['sources']) > 0) {
             $res[] = '## Sources';
             $res[] = sprintf(
-                ' %-25s %13s %13s %13s',
+                ' %-25s %13s %13s %13s %13s %13s',
                 '',
                 'Total',
                 'SPF aligned',
-                'DKIM aligned'
+                'DKIM aligned',
+                'Quarantined',
+                'Rejected'
             );
             foreach ($rdata['sources'] as &$it) {
                 $total    = $it['emails'];
                 $spf_a    = $it['spf_aligned'];
                 $dkim_a   = $it['dkim_aligned'];
+                $qua_a    = $it['quarantined'];
+                $rej_a    = $it['rejected'];
                 $spf_str  = self::num2percent($spf_a, $total);
                 $dkim_str = self::num2percent($dkim_a, $total);
+                $qua_str  = self::num2percent($qua_a, $total);
+                $rej_str  = self::num2percent($rej_a, $total);
                 $res[] = sprintf(
-                    ' %-25s %13d %13s %13s',
+                    ' %-25s %13d %13s %13s %13s %13s',
                     $it['ip'],
                     $total,
                     $spf_str,
-                    $dkim_str
+		    $dkim_str,
+		    $qua_str,
+		    $rej_str
                 );
             }
             unset($it);
@@ -225,6 +235,9 @@ class SummaryReport
         $add_red = function (int $num) {
             return $num > 0 ? 'color:#f00;' : '';
         };
+        $add_orange = function (int $num) {
+            return $num > 0 ? 'color:#f80;' : '';
+        };
         $add_green = function (int $num) {
             return $num > 0 ? 'color:#080;' : '';
         };
@@ -239,11 +252,17 @@ class SummaryReport
         $total = $rdata['summary']['total'];
         $a_cnt = $rdata['summary']['aligned'];
         $n_cnt = $rdata['summary']['n_aligned'];
+        $q_cnt = $rdata['summary']['quarantined'];
+        $r_cnt = $rdata['summary']['rejected'];
         $res[] = " <tr><td>Total: </td><td style=\"{$d1s}\">" . $total . '</td></tr>';
         $color = $add_green($a_cnt);
         $res[] = " <tr><td>DKIM or SPF aligned: </td><td style=\"{$d1s}{$color}\">{$a_cnt}</td></tr>";
-        $color = $add_red($n_cnt);
+        $color = $add_orange($n_cnt);
         $res[] = " <tr><td>Not aligned: </td><td style=\"{$d1s}{$color}\">{$n_cnt}</td></tr>";
+        $color = $add_orange($q_cnt);
+        $res[] = " <tr><td>Quarantined: </td><td style=\"{$d1s}{$color}\">{$q_cnt}</td></tr>";
+        $color = $add_red($r_cnt);
+        $res[] = " <tr><td>Rejected: </td><td style=\"{$d1s}{$color}\">{$r_cnt}</td></tr>";
         $res[] = " <tr><td>Organizations: </td><td style=\"{$d1s}\">" .
                  $rdata['summary']['organizations'] .
                  '</td></tr>';
@@ -259,10 +278,13 @@ class SummaryReport
             $res[] = ' <thead>';
             $style = "style=\"{$d3s}{$d5s}\"";
             $res[] = "  <tr><th {$rs2} {$style}>IP address</th><th {$rs2} {$style}>Email volume</th>" .
-                     "<th {$cs3} {$style}>SPF</th><th {$cs3} {$style}>DKIM</th></tr>";
+                     "<th {$cs3} {$style}>SPF</th><th {$cs3} {$style}>DKIM</th>".
+                     "<th {$cs3} {$style}>Quarantined</th><th {$cs3} {$style}>Rejected</th></tr>";
             $style = "style=\"{$d2s}{$d3s}{$d5s}\"";
             $res[] = "  <tr><th {$style}>pass</th><th {$style}>fail</th><th {$style}>rate</th>" .
-                     "<th {$style}>pass</th><th {$style}>fail</th><th {$style}>rate</th></tr>";
+                     "<th {$style}>pass</th><th {$style}>fail</th><th {$style}>rate</th>".
+		     "<th {$style}>qurantined</th><th {$style}>rate</th>".
+		     "<th {$style}>rejected</th><th {$style}>rate</th></tr>";
             $res[] = ' </thead>';
             $res[] = ' <tbody>';
             foreach ($rdata['sources'] as &$row) {
@@ -274,15 +296,23 @@ class SummaryReport
                 $dkim_a = $row['dkim_aligned'];
                 $dkim_n = $total - $dkim_a;
                 $dkim_p = sprintf('%.0f%%', $dkim_a / $total * 100);
+		$qua_a  = $row['quarantined'];
+		$qua_p  = sprintf('%.0f%%', $qua_a / $total * 100);
+		$rej_a  = $row['rejected'];
+		$rej_p  = sprintf('%.0f%%', $rej_a / $total * 100);
                 $style  = "style=\"{$d3s}{$d5s}";
 
                 $row_str  = "  <tr><td {$style}\">{$ip}</td><td {$style}{$d4s}\">{$total}</td>";
                 $row_str .= "<td {$style}{$d4s}{$add_green($spf_a)}\">{$spf_a}</td>";
-                $row_str .= "<td {$style}{$d4s}{$add_red($spf_n)}\">{$spf_n}</td>";
+                $row_str .= "<td {$style}{$d4s}{$add_orange($spf_n)}\">{$spf_n}</td>";
                 $row_str .= "<td {$style}{$d4s}\">{$spf_p}</td>";
                 $row_str .= "<td {$style}{$d4s}{$add_green($dkim_a)}\">{$dkim_a}</td>";
-                $row_str .= "<td {$style}{$d4s}{$add_red($dkim_n)}\">{$dkim_n}</td>";
+		$row_str .= "<td {$style}{$d4s}{$add_orange($dkim_n)}\">{$dkim_n}</td>";
                 $row_str .= "<td {$style}{$d4s}\">{$dkim_p}</td>";
+                $row_str .= "<td {$style}{$d4s}{$add_orange($qua_a)}\">{$qua_a}</td>";
+                $row_str .= "<td {$style}{$d4s}\">{$qua_p}</td>";
+                $row_str .= "<td {$style}{$d4s}{$add_red($rej_a)}\">{$rej_a}</td>";
+                $row_str .= "<td {$style}{$d4s}\">{$rej_p}</td>";
                 $res[] = $row_str . '</tr>';
             }
             unset($row);
@@ -378,16 +408,22 @@ class SummaryReport
         $aligned   = $summ['emails']['dkim_spf_aligned'] +
                      $summ['emails']['dkim_aligned'] +
                      $summ['emails']['spf_aligned'];
-        $n_aligned = $total - $aligned;
+	$n_aligned = $total - $aligned;
+	$rejected  = $summ['emails']['rejected'];
+	$quarantined = $summ['emails']['quarantined'];
+
         $rdata['summary'] = [
             'total'         => $total,
             'organizations' => $summ['organizations']
         ];
+
+	$rdata['summary']['aligned']     = $aligned;
+        $rdata['summary']['quarantined'] = $quarantined;
+	$rdata['summary']['rejected']    = $rejected;
+
         if ($total > 0) {
-            $rdata['summary']['aligned']   = $aligned;
             $rdata['summary']['n_aligned'] = $n_aligned;
         } else {
-            $rdata['summary']['aligned']   = $aligned;
             $rdata['summary']['n_aligned'] = $aligned;
         }
 

--- a/classes/Settings/SettingsList.php
+++ b/classes/Settings/SettingsList.php
@@ -172,7 +172,7 @@ class SettingsList
             'type'    => 'integer',
             'public'  => true,
             'minimum' => 1,
-            'maximum' => 365,
+            'maximum' => 3650,
             'default' => 30
         ],
         'report-view.sort-records-by' => [

--- a/classes/Settings/SettingsList.php
+++ b/classes/Settings/SettingsList.php
@@ -172,7 +172,7 @@ class SettingsList
             'type'    => 'integer',
             'public'  => true,
             'minimum' => 1,
-            'maximum' => 3650,
+            'maximum' => 365,
             'default' => 30
         ],
         'report-view.sort-records-by' => [

--- a/css/main.css
+++ b/css/main.css
@@ -26,6 +26,8 @@
 		--color-dg-wait:     #080;
 		--color-st-txtblue:  #00f;
 		--color-st-txtgreen: #080;
+		--color-st-txtyellow:   #ff0;
+		--color-st-txtorange:   #f80;
 		--color-st-txtred:   #f00;
 		--color-nt-error:    #f88;
 		--color-nt-warning:  #ff8;
@@ -63,6 +65,8 @@
 		--color-dg-wait:     #c58208;
 		--color-st-txtblue:  #4040ff;
 		--color-st-txtgreen: #009300;
+		--color-st-txtyellow:   #ff2;
+		--color-st-txtorange:   #fa2;
 		--color-st-txtred:   #f22;
 		--color-nt-error:    #da3633;
 		--color-nt-warning:  #e7a100;
@@ -427,6 +431,18 @@ textarea.description {
 	color: var(--color-st-txtred);
 }
 .state-red .state-background {
+	background-color: #f00;
+}
+.state-orange .state-text {
+	color: var(--color-st-txtorange);
+}
+.state-orange .state-background {
+	background-color: #f00;
+}
+.state-yellow .state-text {
+	color: var(--color-st-txtyellow);
+}
+.state-yellow .state-background {
 	background-color: #f00;
 }
 .state-green .state-text {

--- a/css/main.css
+++ b/css/main.css
@@ -26,8 +26,8 @@
 		--color-dg-wait:     #080;
 		--color-st-txtblue:  #00f;
 		--color-st-txtgreen: #080;
-		--color-st-txtyellow:   #ff0;
-		--color-st-txtorange:   #f80;
+		--color-st-txtyellow: #ee0;
+		--color-st-txtorange: #f90;
 		--color-st-txtred:   #f00;
 		--color-nt-error:    #f88;
 		--color-nt-warning:  #ff8;
@@ -65,8 +65,8 @@
 		--color-dg-wait:     #c58208;
 		--color-st-txtblue:  #4040ff;
 		--color-st-txtgreen: #009300;
-		--color-st-txtyellow:   #ff2;
-		--color-st-txtorange:   #fa2;
+		--color-st-txtyellow: #eeee00;
+		--color-st-txtorange: #ff9900;
 		--color-st-txtred:   #f22;
 		--color-nt-error:    #da3633;
 		--color-nt-warning:  #e7a100;
@@ -437,25 +437,19 @@ textarea.description {
 	color: var(--color-st-txtorange);
 }
 .state-orange .state-background {
-	background-color: #f00;
+	background-color: #f90;
 }
 .state-yellow .state-text {
 	color: var(--color-st-txtyellow);
 }
 .state-yellow .state-background {
-	background-color: #f00;
+	background-color: #ee0;
 }
 .state-green .state-text {
 	color: var(--color-st-txtgreen);
 }
 .state-green .state-background {
 	background-color: #080;
-}
-.state-yellow .state-text {
-	color: #f80;
-}
-.state-yellow .state-background {
-	background-color: #f80;
 }
 .state-gray .state-text {
 	color: #888;

--- a/js/list.js
+++ b/js/list.js
@@ -194,7 +194,9 @@ class ReportList {
 			{ content: "Reporting Organization" },
 			{ content: "Report ID", class: "report-id" },
 			{ content: "Messages" },
-			{ content: "Result" }
+			{ content: "Result" },
+			{ content: "Quarantined" },
+			{ content: "Rejected" }
 		].forEach(function(col) {
 			let c = this._table.add_column(col);
 			if (c.name() === this._sort.column) {
@@ -300,6 +302,8 @@ class ReportList {
 		rd.cells.push({ content: d.report_id, class: "report-id" });
 		rd.cells.push({ content: d.messages, label: "Messages" });
 		rd.cells.push(new StatusColumn({ dkim_align: d.dkim_align, spf_align: d.spf_align }));
+		rd.cells.push({ content: d.disposition_reject, label: "Rejected" });
+		rd.cells.push({ content: d.disposition_quarantine, label: "Quarantined" });
 		return rd;
 	}
 
@@ -407,6 +411,7 @@ class ReportListSettingsDialog extends ModalDialog {
 			{ name: "organization", title: "Organization" },
 			{ name: "dkim", title: "DKIM result" },
 			{ name: "spf", title: "SPF result" },
+			{ name: "disposition", title: "Disposition" },
 			{ name: "status", title: "Status" }
 		];
 	}

--- a/js/status.js
+++ b/js/status.js
@@ -97,7 +97,9 @@ class Status {
 				total: -1,
 				spf_aligned: 0,
 				dkim_aligned: 0,
-				dkim_spf_aligned: 0
+				dkim_spf_aligned: 0,
+				quarantined: 0,
+				rejected: 0
 			};
 		}
 		let days = this._data.emails.days;
@@ -105,9 +107,11 @@ class Status {
 		let passed = this._data.emails.dkim_spf_aligned;
 		let forwarded = this._data.emails.dkim_aligned + this._data.emails.spf_aligned;
 		let failed = total - passed - forwarded;
+		let quarantined = this._data.emails.quarantined
+		let rejected = this._data.emails.rejected
 		this._set_element_data(
 			"processed",
-			(total === -1 || total === undefined) && "?" || total,
+			(total === -1 || total === undefined) && "?" || this._iso_formatted(total),
 			total !== -1 && "state-blue" || null
 		);
 		this._set_element_data(
@@ -123,6 +127,16 @@ class Status {
 		this._set_element_data(
 			"failed",
 			this._formatted_statistic(failed, total),
+			total !== -1 && "state-yellow" || null
+		);
+		this._set_element_data(
+			"quarantined",
+			this._formatted_statistic(quarantined, total),
+			total !== -1 && "state-orange" || null
+		);
+		this._set_element_data(
+			"rejected",
+			this._formatted_statistic(rejected, total),
 			total !== -1 && "state-red" || null
 		);
 		{
@@ -134,6 +148,24 @@ class Status {
 				el.removeAttribute("title");
 			}
 		}
+	}
+
+	_iso_formatted(val) {
+		let f = 1;
+		let u = "";
+		if (val > 1000000000) {
+			f = 1000000000;
+			u = "G";
+		}
+		else if (val > 1000000) {
+			f = 1000000;
+			u = "M";
+		}
+		else if (val > 1000) {
+			f = 1000;
+			u = "K";
+		}
+		return (Math.round((val/f + Number.EPSILON) * 100) / 100)+u
 	}
 
 	_formatted_statistic(val, total) {
@@ -187,7 +219,7 @@ Status.instance = function() {
 	return this._instance;
 }
 
-Status._element_list = [ "processed", "passed", "forwarded", "failed" ];
+Status._element_list = [ "processed", "passed", "forwarded", "failed", "quarantined", "rejected" ];
 
 Status._element_data = {
 	processed: {
@@ -201,6 +233,12 @@ Status._element_data = {
 	},
 	failed:	{
 		text: "Not aligned"
+	},
+	quarantined:	{
+		text: "Quarantined"
+	},
+	rejected:	{
+		text: "Rejected"
 	}
 };
 


### PR DESCRIPTION
Failing DKIM or SPF can also be the result of bad (internal) forwarding, so it might be interesting to also show what decisions the reporting servers made regarding the received email.

I added the disposition results to the email summary and in the UI it is part of the listing. In the filter settings I have added disposition. Choosing "quarantine" will also show "rejected" as in that I case would be also interested in those failures. Another option would to just choose between "any" and "failures", but this allows for more precision.