### PR TITLE
phpstan fixes up to level 3

### DIFF
--- a/classes/Admin.php
+++ b/classes/Admin.php
@@ -45,7 +45,7 @@ class Admin
     /**
      * The constructor of the class
      *
-     * @param Core $core Instace of the Core class
+     * @param Core $core Instance of the Core class
      */
     public function __construct($core)
     {

--- a/classes/Core.php
+++ b/classes/Core.php
@@ -243,7 +243,7 @@ class Core
     /**
      * Returns an instance of the class Database.
      *
-     * @return DatabaseController
+     * @return Database\DatabaseController
      */
     public function database()
     {
@@ -264,7 +264,7 @@ class Core
      * Returns the current logger.
      * Just a proxy method to return the logger from ErrorHandler
      *
-     * @return LoggerInterface
+     * @return Log\LoggerInterface
      */
     public function logger()
     {

--- a/classes/Database/DatabaseConnector.php
+++ b/classes/Database/DatabaseConnector.php
@@ -68,7 +68,7 @@ abstract class DatabaseConnector
     /**
      * Returns an instance of PDO class
      *
-     * @return PDO
+     * @return \PDO
      */
     abstract public function dbh(): object;
 

--- a/classes/Database/DatabaseController.php
+++ b/classes/Database/DatabaseController.php
@@ -47,8 +47,8 @@ class DatabaseController
     /**
      * The constructor
      *
-     * @param \Liuch\DmarcSrg\Core  $core       Instance of the Core class
-     * @param DatabaseConnector     $connector  The connector class of the current database
+     * @param \Liuch\DmarcSrg\Core $core      Instance of the Core class
+     * @param DatabaseConnector    $connector The connector class of the current database
      */
     public function __construct($core, $connector = null)
     {

--- a/classes/Database/DatabaseController.php
+++ b/classes/Database/DatabaseController.php
@@ -47,8 +47,8 @@ class DatabaseController
     /**
      * The constructor
      *
-     * @param Core  $core      Instace of the Core class
-     * @param class $connector The connector class of the current database
+     * @param \Liuch\DmarcSrg\Core  $core       Instance of the Core class
+     * @param DatabaseConnector     $connector  The connector class of the current database
      */
     public function __construct($core, $connector = null)
     {

--- a/classes/Database/Mariadb/DomainMapper.php
+++ b/classes/Database/Mariadb/DomainMapper.php
@@ -36,6 +36,7 @@ use Liuch\DmarcSrg\Database\DomainMapperInterface;
 use Liuch\DmarcSrg\Exception\SoftException;
 use Liuch\DmarcSrg\Exception\DatabaseFatalException;
 use Liuch\DmarcSrg\Exception\DatabaseNotFoundException;
+use Liuch\DmarcSrg\Exception\DatabaseException;
 
 /**
  * DomainMapper class implementation for MariaDB
@@ -138,7 +139,7 @@ class DomainMapper implements DomainMapperInterface
                 $st->execute();
                 $st->closeCursor();
             } catch (\PDOException $e) {
-                throw new DababaseException('Failed to update the domain data', -1, $e);
+                throw new DatabaseException('Failed to update the domain data', -1, $e);
             }
         } else {
             try {
@@ -315,9 +316,9 @@ class DomainMapper implements DomainMapperInterface
     /**
      * Binds values for SQL queries based on existing domain data
      *
-     * @param PDOStatement $st   PDO Statement to bind to
-     * @param ind          $pos  Start position for binding
-     * @param array        $data Domain data
+     * @param \PDOStatement $st   PDO Statement to bind to
+     * @param int           $pos  Start position for binding
+     * @param array         $data Domain data
      *
      * @return void
      */

--- a/classes/Database/Mariadb/ReportLogMapper.php
+++ b/classes/Database/Mariadb/ReportLogMapper.php
@@ -56,7 +56,7 @@ class ReportLogMapper implements ReportLogMapperInterface
     /**
      * Fetches data of report log item from the database by id
      *
-     * @param Report log data
+     * @param \Liuch\DmarcSrg\Report\Report $data log data
      *
      * @return void
      */
@@ -286,9 +286,9 @@ class ReportLogMapper implements ReportLogMapperInterface
     /**
      * Binds the values of the filter and the limit to SQL query
      *
-     * @param PDOStatement $st     Prepared SOL statement to bind to
-     * @param array        $filter Key-value array with filter data
-     * @param array        $limit  Key-value array with limit data
+     * @param \PDOStatement $st     Prepared SOL statement to bind to
+     * @param array         $filter Key-value array with filter data
+     * @param array         $limit  Key-value array with limit data
      *
      * @return void
      */

--- a/classes/Database/Mariadb/ReportMapper.php
+++ b/classes/Database/Mariadb/ReportMapper.php
@@ -232,9 +232,9 @@ class ReportMapper implements ReportMapperInterface
      *
      * It has nothing to do with the fields of the report itself.
      *
-     * @param array   $data  Report data
-     * @param string  $name  Property name. Currently only `seen` is supported.
-     * @param bool    $value Property value
+     * @param array  $data  Report data
+     * @param string $name  Property name. Currently only `seen` is supported.
+     * @param mixed  $value Property value
      *
      * @return void
      */

--- a/classes/Database/Mariadb/ReportMapper.php
+++ b/classes/Database/Mariadb/ReportMapper.php
@@ -234,7 +234,7 @@ class ReportMapper implements ReportMapperInterface
      *
      * @param array   $data  Report data
      * @param string  $name  Property name. Currently only `seen` is supported.
-     * @param variant $value Property value
+     * @param bool    $value Property value
      *
      * @return void
      */
@@ -521,9 +521,9 @@ class ReportMapper implements ReportMapperInterface
     /**
      * Binds a nullable array to an SQL query as a json string
      *
-     * @param PDOStatement $st   DB statement object
-     * @param int          $idx  Bind position
-     * @param array        $data JSON data or null
+     * @param \PDOStatement $st   DB statement object
+     * @param int           $idx  Bind position
+     * @param array         $data JSON data or null
      *
      * @return void
      */
@@ -680,7 +680,7 @@ class ReportMapper implements ReportMapperInterface
      * @param array  $f_data Array with prepared filter data
      * @param string $prefix Prefix, which will be added to the beginning of the condition string,
      *                       but only in the case when the condition string is not empty.
-     * @param int    $f_id   Index of the filter
+     * @param int    $f_idx  Index of the filter
      *
      * @return string the condition string
      */
@@ -711,9 +711,9 @@ class ReportMapper implements ReportMapperInterface
     /**
      * Binds the values of the filter and the limit to SQL query
      *
-     * @param PDOStatement $st     Prepared SQL statement to bind to
-     * @param array        $f_data Array with prepared filter data
-     * @param array        $limit  Key-value array with two keys: `offset` and `count`
+     * @param \PDOStatement $st     Prepared SQL statement to bind to
+     * @param array         $f_data Array with prepared filter data
+     * @param array         $limit  Key-value array with two keys: `offset` and `count`
      *
      * @return void
      */
@@ -737,10 +737,10 @@ class ReportMapper implements ReportMapperInterface
     /**
      * Binds the values of the specified filter item to SQL query
      *
-     * @param PDOStatement $st         Prepared SQL statement to bind to
-     * @param array        $f_data     Array with prepared filter data
-     * @param int          $filter_idx Index of the filter to bind to
-     * @param int          $bind_pos   Start bind position (pointer). It will be increaded with each binding.
+     * @param \PDOStatement $st         Prepared SQL statement to bind to
+     * @param array         $f_data     Array with prepared filter data
+     * @param int           $filter_idx Index of the filter to bind to
+     * @param int           $bind_pos   Start bind position (pointer). It will be increased with each binding.
      *
      * @return void
      */

--- a/classes/Database/Mariadb/StatisticsMapper.php
+++ b/classes/Database/Mariadb/StatisticsMapper.php
@@ -54,8 +54,8 @@ class StatisticsMapper implements StatisticsMapperInterface
     /**
      * Returns summary information for the specified domain and date range
      *
-     * @param Domain|null $domain Domain for which the information is needed. Null is for all domains.
-     * @param array       $range  Array with two dates
+     * @param \Liuch\DmarcSrg\Domains\Domain|null $domain Domain for which the information is needed. Null is for all domains.
+     * @param array                               $range  Array with two dates
      *
      * @return array Array with Summary information:
      *                          'emails' => [
@@ -111,8 +111,8 @@ class StatisticsMapper implements StatisticsMapperInterface
     /**
      * Returns a list of ip-addresses from which the e-mail messages were received, with some statistics for each one
      *
-     * @param Domain|null $domain Domain for which the information is needed. Null is for all domains.
-     * @param array       $range  Array with two dates
+     * @param \Liuch\DmarcSrg\Domains\Domain|null $domain Domain for which the information is needed. Null is for all domains.
+     * @param array                               $range  Array with two dates
      *
      * @return array A list of ip-addresses with fields `ip`, `emails`, `dkim_aligned`, `spf_aligned`
      */
@@ -148,8 +148,8 @@ class StatisticsMapper implements StatisticsMapperInterface
     /**
      * Returns a list of organizations that sent the reports with some statistics for each one
      *
-     * @param Domain|null $domain Domain for which the information is needed. Null is for all domains.
-     * @param array       $range  Array with two dates
+     * @param \Liuch\DmarcSrg\Domains\Domain|null $domain Domain for which the information is needed. Null is for all domains.
+     * @param array                               $range  Array with two dates
      *
      * @return array List of organizations with fields `name`, `reports`, `emails`
      */
@@ -202,9 +202,9 @@ class StatisticsMapper implements StatisticsMapperInterface
     /**
      * Binds values for SQL queries
      *
-     * @param PDOStatement $st     PDO Statement to bind to
-     * @param Domain|null  $domain Domain for the condition
-     * @param array        $range  Date range for the condition
+     * @param \PDOStatement                         $st     PDO Statement to bind to
+     * @param \Liuch\DmarcSrg\Domains\Domain|null   $domain Domain for the condition
+     * @param array                                 $range  Date range for the condition
      *
      * @return void
      */

--- a/classes/Database/Mariadb/StatisticsMapper.php
+++ b/classes/Database/Mariadb/StatisticsMapper.php
@@ -202,9 +202,9 @@ class StatisticsMapper implements StatisticsMapperInterface
     /**
      * Binds values for SQL queries
      *
-     * @param \PDOStatement                         $st     PDO Statement to bind to
-     * @param \Liuch\DmarcSrg\Domains\Domain|null   $domain Domain for the condition
-     * @param array                                 $range  Date range for the condition
+     * @param \PDOStatement                       $st     PDO Statement to bind to
+     * @param \Liuch\DmarcSrg\Domains\Domain|null $domain Domain for the condition
+     * @param array                               $range  Date range for the condition
      *
      * @return void
      */

--- a/classes/Database/Mariadb/UpgraderMapper.php
+++ b/classes/Database/Mariadb/UpgraderMapper.php
@@ -192,11 +192,11 @@ class UpgraderMapper implements UpgraderMapperInterface
     }
 
     /**
-     * Checks if the spefied column exists in the spefied table of the database
+     * Checks if the specified column exists in the specified table of the database
      *
      * @param object $db     Connection handle of the database
      * @param string $table  Table name with the prefix
-     * @param string $columb Column name
+     * @param string $column Column name
      *
      * @return bool
      */
@@ -218,7 +218,7 @@ class UpgraderMapper implements UpgraderMapperInterface
     /**
      * Return an instance of DatabaseFatalException
      *
-     * @param Exception $e The original exception
+     * @param \Exception $e The original exception
      *
      * @return DatabaseFatalException
      */

--- a/classes/Database/ReportLogMapperInterface.php
+++ b/classes/Database/ReportLogMapperInterface.php
@@ -36,7 +36,7 @@ interface ReportLogMapperInterface
     /**
      * Fetches data of report log item from the database by id
      *
-     * @param Report log data
+     * @param \Liuch\DmarcSrg\Report\Report $data log data
      *
      * @return void
      */

--- a/classes/Database/ReportMapperInterface.php
+++ b/classes/Database/ReportMapperInterface.php
@@ -61,7 +61,7 @@ interface ReportMapperInterface
      *
      * @param array   $data  Report data
      * @param string  $name  Property name. Currently only `seen` is supported.
-     * @param variant $value Property value
+     * @param mixed   $value Property value
      *
      * @return void
      */

--- a/classes/Database/ReportMapperInterface.php
+++ b/classes/Database/ReportMapperInterface.php
@@ -59,9 +59,9 @@ interface ReportMapperInterface
      *
      * It has nothing to do with the fields of the report itself.
      *
-     * @param array   $data  Report data
-     * @param string  $name  Property name. Currently only `seen` is supported.
-     * @param mixed   $value Property value
+     * @param array  $data  Report data
+     * @param string $name  Property name. Currently only `seen` is supported.
+     * @param mixed  $value Property value
      *
      * @return void
      */

--- a/classes/Database/StatisticsMapperInterface.php
+++ b/classes/Database/StatisticsMapperInterface.php
@@ -37,7 +37,7 @@ interface StatisticsMapperInterface
      * Returns summary information for the specified domain and date range
      *
      * @param \Liuch\DmarcSrg\Domains\Domain|null $domain Domain for which the information is needed. Null is for all domains.
-     * @param array                              $range  Array with two dates
+     * @param array                               $range  Array with two dates
      *
      * @return array Array with Summary information:
      *                          'emails' => [

--- a/classes/Database/StatisticsMapperInterface.php
+++ b/classes/Database/StatisticsMapperInterface.php
@@ -36,8 +36,8 @@ interface StatisticsMapperInterface
     /**
      * Returns summary information for the specified domain and date range
      *
-     * @param Domain|null $domain Domain for which the information is needed. Null is for all domains.
-     * @param array       $range  Array with two dates
+     * @param \Liuch\DmarcSrg\Domains\Domain|null $domain Domain for which the information is needed. Null is for all domains.
+     * @param array                              $range  Array with two dates
      *
      * @return array Array with Summary information:
      *                          'emails' => [
@@ -52,8 +52,8 @@ interface StatisticsMapperInterface
     /**
      * Returns a list of ip-addresses from which the e-mail messages were received, with some statistics for each one
      *
-     * @param Domain|null $domain Domain for which the information is needed. Null is for all domains.
-     * @param array       $range  Array with two dates
+     * @param \Liuch\DmarcSrg\Domains\Domain|null $domain Domain for which the information is needed. Null is for all domains.
+     * @param array                               $range  Array with two dates
      *
      * @return array A list of ip-addresses with fields `ip`, `emails`, `dkim_aligned`, `spf_aligned`
      */
@@ -62,8 +62,8 @@ interface StatisticsMapperInterface
     /**
      * Returns a list of organizations that sent the reports with some statistics for each one
      *
-     * @param Domain|null $domain Domain for which the information is needed. Null is for all domains.
-     * @param array       $range  Array with two dates
+     * @param \Liuch\DmarcSrg\Domains\Domain|null $domain Domain for which the information is needed. Null is for all domains.
+     * @param array                               $range  Array with two dates
      *
      * @return array List of organizations with fields `name`, `reports`, `emails`
      */

--- a/classes/Domains/Domain.php
+++ b/classes/Domains/Domain.php
@@ -40,7 +40,7 @@ use Liuch\DmarcSrg\Exception\DatabaseNotFoundException;
  * It's a class for accessing to stored domains data
  *
  * This class is designed for storing and manipulating domain data.
- * All queries to the datatabase are made in lazy mode.
+ * All queries to the database are made in lazy mode.
  */
 class Domain
 {
@@ -64,14 +64,14 @@ class Domain
      * (new Domain([ 'fqdn' => 'example.com', 'description' => 'an expample domain' ])->save(); - will add
      * this domain to the database if it does not exist in it.
      *
-     * @param int|string|array   $data Some domain data to identify it
-     *                                 int value is treated as domain id
-     *                                 string value is treated as a FQDN
-     *                                 array has these fields: `id`, `fqdn`, `active`, `description`
-     *                                 and usually uses for creating a new domain item.
-     *                                 Note: The values of the fields `created_time` and `updated_time`
-     *                                 will be ignored while saving to the database.
-     * @param DatabaseController $db   The database controller
+     * @param int|string|array                            $data Some domain data to identify it
+     *                                                          int value is treated as domain id
+     *                                                          string value is treated as a FQDN
+     *                                                          array has these fields: `id`, `fqdn`, `active`, `description`
+     *                                                          and usually uses for creating a new domain item.
+     *                                                          Note: The values of the fields `created_time` and `updated_time`
+     *                                                          will be ignored while saving to the database.
+     * @param \Liuch\DmarcSrg\Database\DatabaseController $db   The database controller
      *
      * @return void
      */

--- a/classes/Domains/DomainList.php
+++ b/classes/Domains/DomainList.php
@@ -43,7 +43,7 @@ class DomainList
     /**
      * The constructor
      *
-     * @param DatabaseController $db The database controller
+     * @param \Liuch\DmarcSrg\Database\DatabaseController $db The database controller
      */
     public function __construct($db = null)
     {

--- a/classes/ErrorHandler.php
+++ b/classes/ErrorHandler.php
@@ -56,7 +56,7 @@ class ErrorHandler implements LoggerAwareInterface
     /**
      * Handle uncaught exceptions. Used by set_exception_handler and set_error_handler functions
      *
-     * @param Throwable $e an exception to handle. For set_error_handler it is ErrorException.
+     * @param \Throwable $e an exception to handle. For set_error_handler it is ErrorException.
      *
      * @return void
      */
@@ -80,7 +80,7 @@ class ErrorHandler implements LoggerAwareInterface
      * Returns an result array based on the passed exception's data.
      * If the debug mode is enabled, the `debug_info` field will be added to the result.
      *
-     * @param Throwable $e an exception for which the result is generated
+     * @param \Throwable $e an exception for which the result is generated
      *
      * @return array
      */
@@ -93,7 +93,7 @@ class ErrorHandler implements LoggerAwareInterface
      * Returns information about the passed exception as text.
      * If the debug is enabled, debug information will be added.
      *
-     * @param Throwable $e an exception for which the text is generated
+     * @param \Throwable $e an exception for which the text is generated
      *
      * @return string
      */

--- a/classes/Exception/DatabaseExceptionFactory.php
+++ b/classes/Exception/DatabaseExceptionFactory.php
@@ -39,7 +39,7 @@ class DatabaseExceptionFactory
     /**
      * Creates a DatabaseException instance with an appropriate message based on the passed class's name and error code.
      *
-     * @param Exception $origin The original exception
+     * @param \Exception $origin The original exception
      *
      * @return DatabaseException
      */

--- a/classes/Report/ReportList.php
+++ b/classes/Report/ReportList.php
@@ -54,7 +54,7 @@ class ReportList
     /**
      * The constructor
      *
-     * @param DatabaseController $db The database controller
+     * @param \Liuch\DmarcSrg\Database\DatabaseController $db The database controller
      */
     public function __construct($db = null)
     {

--- a/classes/Report/SummaryReport.php
+++ b/classes/Report/SummaryReport.php
@@ -89,7 +89,7 @@ class SummaryReport
     /**
      * Binds a domain to the report
      *
-     * @param Domain $domain The domain for which the report is created
+     * @param \Liuch\DmarcSrg\Domains\Domain $domain The domain for which the report is created
      *
      * @return self
      */

--- a/classes/ReportLog/ReportLogItem.php
+++ b/classes/ReportLog/ReportLogItem.php
@@ -84,7 +84,7 @@ class ReportLogItem
     /**
      * Returns an instance of ReportLogItem with the passed Id
      *
-     * @param int                                        $id Item Id to return
+     * @param int                                         $id Item Id to return
      * @param \Liuch\DmarcSrg\Database\DatabaseController $db The database controller
      *
      * @return ReportLogItem an instance of ReportLogItem with the specified Id.

--- a/classes/ReportLog/ReportLogItem.php
+++ b/classes/ReportLog/ReportLogItem.php
@@ -84,8 +84,8 @@ class ReportLogItem
     /**
      * Returns an instance of ReportLogItem with the passed Id
      *
-     * @param int                $id Item Id to return
-     * @param DatabaseController $db The database controller
+     * @param int                                        $id Item Id to return
+     * @param \Liuch\DmarcSrg\Database\DatabaseController $db The database controller
      *
      * @return ReportLogItem an instance of ReportLogItem with the specified Id.
      */

--- a/classes/Settings/Setting.php
+++ b/classes/Settings/Setting.php
@@ -39,7 +39,7 @@ use Liuch\DmarcSrg\Exception\DatabaseNotFoundException;
  * It's a class for accessing to settings item data
  *
  * This class is designed for storing and manipulating one item of settings data.
- * All queries to the datatabase are made in lazy mode.
+ * All queries to the database are made in lazy mode.
  */
 abstract class Setting
 {
@@ -90,13 +90,13 @@ abstract class Setting
      * (new Setting([ 'name' => 'some.setting', 'value' => 'some string value' ])->save(); - will add
      * this setting to the database if it does not exist in it or update the value of the setting.
      *
-     * @param string|array       $data    Some setting data to identify it
-     *                                    string value is treated as a name
-     *                                    array has these fields: `name`, `value`
-     *                                    and usually uses for creating a new setting item.
-     * @param boolean            $wignore If true the wrong value is reset to the default
-     *                                    or it throws an exception otherwise.
-     * @param DatabaseController $db      The database controller
+     * @param string|array                                $data    Some setting data to identify it
+     *                                                             string value is treated as a name
+     *                                                             array has these fields: `name`, `value`
+     *                                                             and usually uses for creating a new setting item.
+     * @param boolean                                     $wignore If true the wrong value is reset to the default
+     *                                                             or it throws an exception otherwise.
+     * @param \Liuch\DmarcSrg\Database\DatabaseController $db      The database controller
      *
      * @return void
      */
@@ -155,7 +155,7 @@ abstract class Setting
     /**
      * Assigns the passed value to the setting
      *
-     * @param mixed Value to assign
+     * @param mixed $value Value to assign
      *
      * @return void
      */

--- a/classes/Settings/SettingsList.php
+++ b/classes/Settings/SettingsList.php
@@ -48,7 +48,7 @@ class SettingsList
     /**
      * The constructor
      *
-     * @param DatabaseController $db Connector to the current database
+     * @param \Liuch\DmarcSrg\Database\DatabaseController $db Connector to the current database
      */
     public function __construct($db = null)
     {

--- a/classes/Sources/MailboxSource.php
+++ b/classes/Sources/MailboxSource.php
@@ -171,7 +171,7 @@ class MailboxSource extends Source
     /**
      * Returns the current email message.
      *
-     * @return MailMessage|null
+     * @return \Liuch\DmarcSrg\Mail\MailMessage|null
      */
     public function mailMessage()
     {

--- a/classes/Sources/Source.php
+++ b/classes/Sources/Source.php
@@ -45,7 +45,7 @@ abstract class Source implements \Iterator
     /**
      * Constructor
      *
-     * @param mixed Data to reach report files
+     * @param mixed $data Data to reach report files
      *
      * @return void
      */
@@ -55,7 +55,7 @@ abstract class Source implements \Iterator
     }
 
     /**
-     * Sets parameters that difine the behavior of the source
+     * Sets parameters that define the behavior of the source
      *
      * @param $params Key-value array
      *                'when_done'   => one or more rules to be executed after successful report processing
@@ -106,7 +106,7 @@ abstract class Source implements \Iterator
     /**
      * Returns the source itself that was passed to the constructor
      *
-     * @return class
+     * @return mixed
      */
     public function container()
     {

--- a/classes/Statistics.php
+++ b/classes/Statistics.php
@@ -48,8 +48,8 @@ class Statistics
     /**
      * The constructor of the class, it only uses in static methods of this class
      *
-     * @param Domain|null        $domain The domain for which you need to get statistics, null for all the domains.
-     * @param DatabaseController $db     The database controller
+     * @param Domains\Domain|null         $domain The domain for which you need to get statistics, null for all the domains.
+     * @param Database\DatabaseController $db     The database controller
      *
      * @return void
      */
@@ -62,10 +62,10 @@ class Statistics
     /**
      * Returns an instance of the class for the period from $date1 to $date2
      *
-     * @param Domain|null        $domain See the constructor for the details
-     * @param DateTime           $date1  The date you need statistics from
-     * @param DateTime           $date2  The date you need statistics to (not included)
-     * @param DatabaseController $db     The database controller
+     * @param Domains\Domain|null         $domain See the constructor for the details
+     * @param DateTime                    $date1  The date you need statistics from
+     * @param DateTime                    $date2  The date you need statistics to (not included)
+     * @param Database\DatabaseController $db     The database controller
      *
      * @return Statistics Instance of the class
      */
@@ -80,8 +80,8 @@ class Statistics
     /**
      * Returns an instance of the class for the last week
      *
-     * @param Domain|null        $domain See the constructor for the details
-     * @param DatabaseController $db     The database controller
+     * @param Domains\Domain|null         $domain See the constructor for the details
+     * @param Database\DatabaseController $db     The database controller
      *
      * @return Statistics Instance of the class
      */
@@ -96,8 +96,8 @@ class Statistics
     /**
      * Returns an instance of the class for the last month
      *
-     * @param Domain|null        $domain See the construct for the details
-     * @param DatabaseController $db     The database controller
+     * @param Domains\Domain|null         $domain See the construct for the details
+     * @param Database\DatabaseController $db     The database controller
      *
      * @return Statistics Instance of the class
      */
@@ -112,9 +112,9 @@ class Statistics
     /**
      * Returns an instance of the class for the last N days
      *
-     * @param Domain|null        $domain See the construct for the details
-     * @param int                $ndays  Number of days
-     * @param DatabaseController $db     The database controller
+     * @param Domains\Domain|null         $domain See the construct for the details
+     * @param int                         $ndays  Number of days
+     * @param Database\DatabaseController $db     The database controller
      *
      * @return Statistics Instance of the class
      */

--- a/logout.php
+++ b/logout.php
@@ -23,7 +23,7 @@
 namespace Liuch\DmarcSrg;
 
 use Liuch\DmarcSrg\ErrorHandler;
-use Liuch\DmarcSrg\RuntimeException;
+use Liuch\DmarcSrg\Exception\RuntimeException;
 
 require 'init.php';
 


### PR DESCRIPTION
Ref: https://github.com/liuch/dmarc-srg/pull/74#issuecomment-1596335453

phpstan is a tool that analyses your PHP code without running it and finds bugs or mistakes

In this PR I think 2 bugs are killed:
- typo in class name + missing use in `classes/Database/Mariadb/DomainMapper.php`
- missing use in `logout.php`

This is the errors that I did not fix

```
 ------ ---------------------------------------------------------------------- 
  Line   classes/Config.php                                                    
 ------ ---------------------------------------------------------------------- 
  83     Variable $data on left side of ?? always exists and is not nullable.  
 ------ ---------------------------------------------------------------------- 

 ------ ---------------------------------------------------------------------------------------------------------------------- 
  Line   classes/Database/Mariadb/ReportLogMapper.php                                                                          
 ------ ---------------------------------------------------------------------------------------------------------------------- 
  63     PHPDoc tag @param for parameter $data with type Liuch\DmarcSrg\Report\Report is incompatible with native type array.  
 ------ ---------------------------------------------------------------------------------------------------------------------- 

 ------ -------------------------------------------------------------- 
  Line   classes/Database/Mariadb/ReportMapper.php                     
 ------ -------------------------------------------------------------- 
  158    Offset 'active' does not exist on array{fqdn: string}.        
  589    Offset 'id' does not exist on array{fqdn: non-falsy-string}.  
 ------ -------------------------------------------------------------- 

 ------ ---------------------------------------------------------------------------------------------------------------------- 
  Line   classes/Database/ReportLogMapperInterface.php                                                                         
 ------ ---------------------------------------------------------------------------------------------------------------------- 
  43     PHPDoc tag @param for parameter $data with type Liuch\DmarcSrg\Report\Report is incompatible with native type array.  
 ------ ---------------------------------------------------------------------------------------------------------------------- 

 ------ --------------------------------------- 
  Line   classes/Mail/MailBody.php              
 ------ --------------------------------------- 
  133    Variable $ctype might not be defined.  
 ------ --------------------------------------- 

 ------ --------------------------------------- 
  Line   classes/Report/ReportFetcher.php       
 ------ --------------------------------------- 
  92     Variable $s_act might not be defined.  
  93     Variable $f_act might not be defined.  
 ------ --------------------------------------- 

 ------ -------------------------------------- 
  Line   classes/Settings/Setting.php          
 ------ -------------------------------------- 
  195    Variable $type might not be defined.  
 ------ -------------------------------------- 

 ------ ------------------------------------------------------------------------------------------------------------------------------------------------ 
  Line   classes/Settings/SettingsList.php                                                                                                               
 ------ ------------------------------------------------------------------------------------------------------------------------------------------------ 
  97     Variable $list might not be defined.                                                                                                            
  102    Variable $list might not be defined.                                                                                                            
  153    Method Liuch\DmarcSrg\Settings\SettingsList::getSettingByName() should return Liuch\DmarcSrg\Settings\Setting but return statement is missing.  
 ------ ------------------------------------------------------------------------------------------------------------------------------------------------ 

 ------ -------------------------------------------------------------------- 
  Line   classes/Statistics.php                                              
 ------ -------------------------------------------------------------------- 
  59     Variable $db on left side of ?? always exists and is not nullable.  
 ------ -------------------------------------------------------------------- 

 ------ -------------------------------------------------------------- 
  Line   files.php                                                     
 ------ -------------------------------------------------------------- 
  50     Variable $up_size in empty() always exists and is not falsy.  
 ------ -------------------------------------------------------------- 

                                                                                                                        
 [ERROR] Found 14 errors                                                                                                
                                                                                                                        
```
