### PR TITLE
Error fix

### DIFF
--- a/classes/Mail/MailMessage.php
+++ b/classes/Mail/MailMessage.php
@@ -108,7 +108,7 @@ class MailMessage
                 // when it's an entire attached message: MESSAGE/RFC822
                 if (isset($part->parts) && count($part->parts) > 0) {
                     foreach ($part->parts as $subIndex => &$subPart) {
-                        $allParts[$msgIndex . '.' . $subIndex + 1] = $subPart;
+                        $allParts[$msgIndex . '.' . ($subIndex + 1)] = $subPart;
                     }
                     unset($subPart);// Remove the last dangling reference
                     continue;


### PR DESCRIPTION
Simple fix for this error:

```
david@puffin:/data/www/dmarc-srg$ php utils/fetch_reports.php
dmarc-srg [error]: ErrorException: The behavior of unparenthesized expressions containing both '.' and '+'/'-' will change in PHP 8: '+'/'-' will take a higher precedence in /data/www/dmarc-srg/classes/Mail/MailMessage.php:111
Stack trace:
#0 /data/www/dmarc-srg/init.php(32): {closure}(8192, 'The behavior of...', '/data/www/virtu...', 111, Array)
#1 /data/www/dmarc-srg/init.php(32): require_once()
#2 [internal function]: {closure}('Liuch\\DmarcSrg\\...')
#3 /data/www/dmarc-srg/classes/Mail/MailBox.php(233): spl_autoload_call('Liuch\\DmarcSrg\\...')
#4 /data/www/dmarc-srg/classes/Sources/MailboxSource.php(81): Liuch\DmarcSrg\Mail\MailBox->message(1)
#5 /data/www/dmarc-srg/classes/Report/ReportFetcher.php(113): Liuch\DmarcSrg\Sources\MailboxSource->current()
#6 /data/www/dmarc-srg/utils/fetch_reports.php(160): Liuch\DmarcSrg\Report\ReportFetcher->fetch()
#7 {main}
Error: The behavior of unparenthesized expressions containing both '.' and '+'/'-' will change in PHP 8: '+'/'-' will take a higher precedence (-1)
```

Tested on PHP 7.4.33