### PR TITLE
fix undefined property usage

### DIFF
--- a/classes/Database/Mariadb/ReportMapper.php
+++ b/classes/Database/Mariadb/ReportMapper.php
@@ -394,7 +394,7 @@ class ReportMapper implements ReportMapperInterface
      */
     public function delete(array &$filter, array &$order, array &$limit): void
     {
-        if ($this->user->id()) {
+        if (Core::instance()->user()->id()) {
             throw new LogicException('Attempted deletion of reports by non-admin user');
         }
         $f_data = $this->prepareFilterData($filter);


### PR DESCRIPTION
reports_cleaner scripts was failing with the following error
```
dmarc-srg [error]: ErrorException: Undefined property: Liuch\DmarcSrg\Database\Mariadb\ReportMapper::$user in /var/www/dmarc-srg/classes/Database/Mariadb/ReportMapper.php:397
Stack trace:
#0 /var/www/dmarc-srg/classes/Database/Mariadb/ReportMapper.php(397): {closure}(2, 'Undefined prope...', '/var/www/dmarc-...', 397)
#1 /var/www/dmarc-srg/classes/Report/ReportList.php(187): Liuch\DmarcSrg\Database\Mariadb\ReportMapper->delete(Array, Array, Array)
#2 /var/www/dmarc-srg/utils/reports_cleaner.php(78): Liuch\DmarcSrg\Report\ReportList->delete()
#3 {main}
Error: Undefined property: Liuch\DmarcSrg\Database\Mariadb\ReportMapper::$user (-1)
```