### PR TITLE
Include `php-cgi` in security check for cron and cli #136

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,11 @@ For example, if you want to get a summary report for the last week, you should r
 
 `$ php /usr/local/share/dmarc-srg/utils/summary_report.php domain=example.com period=lastweek`
 
+If you receive an error message suggesting register_argc_argv is disabled, you can enable it like this:
+
+`$ php /usr/local/share/dmarc-srg/utils/summary_report.php domain=example.com period=lastweek`
+
+
 # Web interface
 Use the public/ directory to access the web interface. You will see the basic Report List view, allowing you to navigate through the reports that have been parsed. Using the menu go to the Admin section and create tables in the database and check the accessibility of the mailboxes if necessary.
 

--- a/utils/check_config.php
+++ b/utils/check_config.php
@@ -42,7 +42,7 @@ use Liuch\DmarcSrg\RemoteFilesystems\RemoteFilesystemList;
 
 require realpath(__DIR__ . '/..') . '/init.php';
 
-if (php_sapi_name() !== 'cli') {
+if (php_sapi_name() !== 'cli' && php_sapi_name() !== 'cgi-fcgi') {
     echo 'Forbidden';
     exit(1);
 }

--- a/utils/database_admin.php
+++ b/utils/database_admin.php
@@ -44,7 +44,7 @@ use Liuch\DmarcSrg\Exception\RuntimeException;
 
 require realpath(__DIR__ . '/..') . '/init.php';
 
-if (php_sapi_name() !== 'cli') {
+if (php_sapi_name() !== 'cli' && php_sapi_name() !== 'cgi-fcgi') {
     echo 'Forbidden';
     exit(1);
 }

--- a/utils/domains_admin.php
+++ b/utils/domains_admin.php
@@ -75,7 +75,7 @@ use Liuch\DmarcSrg\Exception\RuntimeException;
 
 require realpath(__DIR__ . '/..') . '/init.php';
 
-if (php_sapi_name() !== 'cli') {
+if (php_sapi_name() !== 'cli' && php_sapi_name() !== 'cgi-fcgi') {
     echo 'Forbidden';
     exit(1);
 }

--- a/utils/fetch_reports.php
+++ b/utils/fetch_reports.php
@@ -56,7 +56,7 @@ use Liuch\DmarcSrg\RemoteFilesystems\RemoteFilesystemList;
 
 require realpath(__DIR__ . '/..') . '/init.php';
 
-if (php_sapi_name() !== 'cli') {
+if (php_sapi_name() !== 'cli' && php_sapi_name() !== 'cgi-fcgi') {
     echo 'Forbidden';
     exit(1);
 }

--- a/utils/mailbox_cleaner.php
+++ b/utils/mailbox_cleaner.php
@@ -41,7 +41,7 @@ use Liuch\DmarcSrg\Exception\RuntimeException;
 
 require realpath(__DIR__ . '/..') . '/init.php';
 
-if (php_sapi_name() !== 'cli') {
+if (php_sapi_name() !== 'cli' && php_sapi_name() !== 'cgi-fcgi') {
     echo 'Forbidden';
     exit(1);
 }

--- a/utils/reportlog_cleaner.php
+++ b/utils/reportlog_cleaner.php
@@ -38,7 +38,7 @@ use Liuch\DmarcSrg\Exception\RuntimeException;
 
 require realpath(__DIR__ . '/..') . '/init.php';
 
-if (php_sapi_name() !== 'cli') {
+if (php_sapi_name() !== 'cli' && php_sapi_name() !== 'cgi-fcgi') {
     echo 'Forbidden';
     exit(1);
 }

--- a/utils/reports_cleaner.php
+++ b/utils/reports_cleaner.php
@@ -39,7 +39,7 @@ use Liuch\DmarcSrg\Exception\RuntimeException;
 
 require realpath(__DIR__ . '/..') . '/init.php';
 
-if (php_sapi_name() !== 'cli') {
+if (php_sapi_name() !== 'cli' && php_sapi_name() !== 'cgi-fcgi') {
     echo 'Forbidden';
     exit(1);
 }

--- a/utils/summary_report.php
+++ b/utils/summary_report.php
@@ -74,7 +74,7 @@ use Liuch\DmarcSrg\Exception\RuntimeException;
 
 require realpath(__DIR__ . '/..') . '/init.php';
 
-if (php_sapi_name() !== 'cli') {
+if (php_sapi_name() !== 'cli' && php_sapi_name() !== 'cgi-fcgi') {
     echo 'Forbidden' . PHP_EOL;
     exit(1);
 }

--- a/utils/users_admin.php
+++ b/utils/users_admin.php
@@ -88,7 +88,7 @@ use Liuch\DmarcSrg\Exception\RuntimeException;
 
 require realpath(__DIR__ . '/..') . '/init.php';
 
-if (php_sapi_name() !== 'cli') {
+if (php_sapi_name() !== 'cli' && php_sapi_name() !== 'cgi-fcgi') {
     echo 'Forbidden';
     exit(1);
 }


### PR DESCRIPTION
Adds `cgi-fcgi` check allowing servers that run cron jobs from `php-cgi` to execute. #136 