### PR TITLE
Doc: add and fix docs for summary report subject line

### DIFF
--- a/utils/summary_report.php
+++ b/utils/summary_report.php
@@ -40,7 +40,7 @@
  *   when the `domain` options is set to `all`. Only makes sense if the user_management mode is active.
  *   The default value is `admin`.
  * The `subject` parameter is optional. It allows you to specify the subject line of the summary report message
- *   instead of the default subject line. Remember to escape spaces and special characters!
+ *   instead of the default subject line. Remember to escape spaces and special characters using HTML entities!
  *
  * Some examples:
  *

--- a/utils/summary_report.php
+++ b/utils/summary_report.php
@@ -50,7 +50,7 @@
  * $ php utils/summary_report.php domain=example.com period=lastweek offset=1
  * will send a summary report for the week before last week for the domain example.com via email
  *
- * $ php utils/summary_report.php domain=example.com period=lastndays:10 "subject:My cool summary report"
+ * $ php utils/summary_report.php domain=example.com period=lastndays:10 "subject=My cool summary report"
  * will send a summary report for last 10 days for the domain example.com via email with the specified subject line
  *
  * $ php utils/summary_report.php domain=all user=frederick1 period=lastmonth emailto=frederick@example.com

--- a/utils/summary_report.php
+++ b/utils/summary_report.php
@@ -101,6 +101,7 @@ if ($acount <= 1) {
     echo '           period=lastmonth|lastweek|lastndays:<days>', PHP_EOL;
     echo '           [offset=<days>] [format=text|html|text+html]', PHP_EOL;
     echo '           [emailto=<email address>] [user=<username>]', PHP_EOL;
+    echo '           [subject="<subject line>"]', PHP_EOL;
     exit(1);
 }
 for ($i = 1; $i < $acount; ++$i) {

--- a/utils/summary_report.php
+++ b/utils/summary_report.php
@@ -50,7 +50,7 @@
  * $ php utils/summary_report.php domain=example.com period=lastweek offset=1
  * will send a summary report for the week before last week for the domain example.com via email
  *
- * $ php utils/summary_report.php domain=example.com period=lastndays:10 "subject=My cool summary report"
+ * $ php utils/summary_report.php domain=example.com period=lastndays:10 subject="My cool summary report"
  * will send a summary report for last 10 days for the domain example.com via email with the specified subject line
  *
  * $ php utils/summary_report.php domain=all user=frederick1 period=lastmonth emailto=frederick@example.com


### PR DESCRIPTION
I added the subject line to the cli help response, and updated the code doc to use `=` for the parameter, and fixed where the quoting was.

The example uses unescaped spaces, which works fine for me. But the code says spaces must be escaped. I didn't fix this inconsistency, as you may want to go in a direction where one or the other is required. But as it seems to work with spaces, I'd recommend leaving it as allowing unescaped spaces.

Thanks for implimenting the subject line feature.