### PR TITLE
fix done messages not being cleaned up

### DIFF
--- a/utils/mailbox_cleaner.php
+++ b/utils/mailbox_cleaner.php
@@ -89,6 +89,9 @@ foreach ([ [ 'done', '', 1 ], [ 'failed', 'failed', 0 ] ] as $it) {
                 $dir = $act->param;
                 break;
             }
+            elseif ($act->type === SourceAction::ACTION_SEEN) {
+                $dir = $def_opt;
+            }
         }
         if (is_null($dir)) {
             continue;

--- a/utils/mailbox_cleaner.php
+++ b/utils/mailbox_cleaner.php
@@ -88,8 +88,7 @@ foreach ([ [ 'done', '', 1 ], [ 'failed', 'failed', 0 ] ] as $it) {
             if ($act->type === SourceAction::ACTION_MOVE) {
                 $dir = $act->param;
                 break;
-            }
-            elseif ($act->type === SourceAction::ACTION_SEEN) {
+            } elseif ($act->type === SourceAction::ACTION_SEEN) {
                 $dir = $def_opt;
             }
         }


### PR DESCRIPTION
Hi,

This PR fix an problem with `utils/mailbox_cleaner.php` where done messages were ignored when `fetcher/mailboxes/when_done` was set on `mark_seen`