### PR TITLE
Add github actions with matrix for different PHP versions

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -1,0 +1,41 @@
+name: build-lint-etc
+on: [ push ]
+
+jobs:
+  testsuite:
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        php-versions: [ '7.3', '7.4', '8.0', '8.1', '8.2', '8.3' ]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-versions }}
+          tools: composer
+          extensions: sqlite3, gd, mbstring
+
+      - name: Get composer cache directory
+        if: ${{ !env.ACT }}
+        id: composer-cache
+        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+
+      - name: Cache dependencies
+        if: ${{ !env.ACT }}
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ matrix.php-versions}}-${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: ${{ runner.os }}-composer-
+
+      - name: Install dependencies
+        run: composer install --prefer-dist -n
+
+      - name: lint
+        run: composer lint
+
+      - name: static analysis
+        run: composer phpstan

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,12 @@
     "name": "liuch/dmarc-srg",
     "type": "project",
     "description": "A php parser, viewer and summary report generator for incoming DMARC reports.",
-    "keywords": [ "mailserver", "dmarc", "dmarc-reports", "dmarc-parser" ],
+    "keywords": [
+        "mailserver",
+        "dmarc",
+        "dmarc-reports",
+        "dmarc-parser"
+    ],
     "license": "GPL-3.0-only",
     "authors": [
         {
@@ -22,7 +27,12 @@
         "league/flysystem-aws-s3-v3": "^2.5 || ^3.25.1"
     },
     "require-dev": {
+        "php-parallel-lint/php-parallel-lint": "*",
         "phpstan/phpstan": "^2.0"
+    },
+    "scripts": {
+        "phpstan" : "@php vendor/bin/phpstan analyse -- classes utils public config ",
+        "lint": "@php vendor/bin/parallel-lint --exclude vendor/ ."
     },
     "suggest": {
         "ext-imap": "Needed to process incoming DMARC reports stored in a mailbox"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0f51a793cb8afcf54dd596fd1fbb24be",
+    "content-hash": "0acb6f4418e8dacae4a70313cdb4506c",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -62,16 +62,16 @@
         },
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.343.22",
+            "version": "3.346.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "174cc187df3bde52c21e9c00a4e99610a08732a3"
+                "reference": "d1403b5a39af7ab7af4fc538deb33013c19c8d33"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/174cc187df3bde52c21e9c00a4e99610a08732a3",
-                "reference": "174cc187df3bde52c21e9c00a4e99610a08732a3",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/d1403b5a39af7ab7af4fc538deb33013c19c8d33",
+                "reference": "d1403b5a39af7ab7af4fc538deb33013c19c8d33",
                 "shasum": ""
             },
             "require": {
@@ -153,9 +153,9 @@
             "support": {
                 "forum": "https://github.com/aws/aws-sdk-php/discussions",
                 "issues": "https://github.com/aws/aws-sdk-php/issues",
-                "source": "https://github.com/aws/aws-sdk-php/tree/3.343.22"
+                "source": "https://github.com/aws/aws-sdk-php/tree/3.346.2"
             },
-            "time": "2025-05-30T18:11:02+00:00"
+            "time": "2025-06-20T18:10:21+00:00"
         },
         {
             "name": "guzzlehttp/guzzle",
@@ -1226,6 +1226,67 @@
         }
     ],
     "packages-dev": [
+        {
+            "name": "php-parallel-lint/php-parallel-lint",
+            "version": "v1.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-parallel-lint/PHP-Parallel-Lint.git",
+                "reference": "6db563514f27e19595a19f45a4bf757b6401194e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-parallel-lint/PHP-Parallel-Lint/zipball/6db563514f27e19595a19f45a4bf757b6401194e",
+                "reference": "6db563514f27e19595a19f45a4bf757b6401194e",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "php": ">=5.3.0"
+            },
+            "replace": {
+                "grogy/php-parallel-lint": "*",
+                "jakub-onderka/php-parallel-lint": "*"
+            },
+            "require-dev": {
+                "nette/tester": "^1.3 || ^2.0",
+                "php-parallel-lint/php-console-highlighter": "0.* || ^1.0",
+                "squizlabs/php_codesniffer": "^3.6"
+            },
+            "suggest": {
+                "php-parallel-lint/php-console-highlighter": "Highlight syntax in code snippet"
+            },
+            "bin": [
+                "parallel-lint"
+            ],
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "./src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Jakub Onderka",
+                    "email": "ahoj@jakubonderka.cz"
+                }
+            ],
+            "description": "This tool checks the syntax of PHP files about 20x faster than serial check.",
+            "homepage": "https://github.com/php-parallel-lint/PHP-Parallel-Lint",
+            "keywords": [
+                "lint",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/php-parallel-lint/PHP-Parallel-Lint/issues",
+                "source": "https://github.com/php-parallel-lint/PHP-Parallel-Lint/tree/v1.4.0"
+            },
+            "time": "2024-03-27T12:14:49+00:00"
+        },
         {
             "name": "phpstan/phpstan",
             "version": "2.1.17",


### PR DESCRIPTION

 * Adds php-parallel-lint to composer.json
 * Adds github action support - where the build runs phpstan and parallel-lint for each php version
 * Add 'scripts' to composer.json to save future typing 
