### PR TITLE
fix: check token length before comparison in isTokenValid

### DIFF
--- a/classes/Auth.php
+++ b/classes/Auth.php
@@ -179,12 +179,12 @@ class Auth
                 break;
         }
 
-        if ($token !== $realToken) {
-            throw new AuthException('Invalid token');
-        }
-
         if (strlen($token) < 20) {
             throw new AuthException('Token is too short');
+        }
+
+        if ($token !== $realToken) {
+            throw new AuthException('Invalid token');
         }
     }
 }


### PR DESCRIPTION
Swaps the order of the length and equality checks so that misconfigured short tokens are rejected early instead of authenticating and then throwing a confusing error.