### PR TITLE
fix: guard against division by zero in num2percent

### DIFF
--- a/classes/Common.php
+++ b/classes/Common.php
@@ -120,7 +120,8 @@ class Common
     }
 
     /**
-     * Returns the percentage with the original number. If $per is 0 then '0' is returned.
+     * Returns the percentage with the original number.
+     * Returns '0' if $per is 0, '-' if $cent is 0.
      *
      * @param int  $per      Value
      * @param int  $cent     Divisor for percentage calculation
@@ -130,7 +131,10 @@ class Common
      */
     public static function num2percent(int $per, int $cent, bool $with_num): string
     {
-        if (!$per || !$cent) {
+        if (!$cent) {
+            return '-';
+        }
+        if (!$per) {
             return '0';
         }
         $res = sprintf('%.0f%%', $per / $cent * 100);

--- a/classes/Common.php
+++ b/classes/Common.php
@@ -130,7 +130,7 @@ class Common
      */
     public static function num2percent(int $per, int $cent, bool $with_num): string
     {
-        if (!$per) {
+        if (!$per || !$cent) {
             return '0';
         }
         $res = sprintf('%.0f%%', $per / $cent * 100);

--- a/public/js/summary.js
+++ b/public/js/summary.js
@@ -595,7 +595,8 @@ class SummaryReport {
 	}
 
 	static num2percent(per, cent, with_num) {
-		if (!per) return 0;
+		if (!cent) return "-";
+		if (!per) return "0";
 		let res = "" + Math.round(per / cent * 100) + "%";
 		if (with_num) res += " (" + per + ")";
 		return res;

--- a/tests/classes/CommonTest.php
+++ b/tests/classes/CommonTest.php
@@ -38,4 +38,15 @@ class CommonTest extends \PHPUnit\Framework\TestCase
         $this->assertNotEquals(Common::randomString(4), Common::randomString(4));
         $this->assertMatchesRegularExpression('/^[0-9a-zA-Z]+$/', Common::randomString(64));
     }
+
+    public function testNum2Percent(): void
+    {
+        $this->assertEquals('50%', Common::num2percent(1, 2, false));
+        $this->assertEquals('50%(1)', Common::num2percent(1, 2, true));
+        $this->assertEquals('0', Common::num2percent(0, 2, false));
+        $this->assertEquals('0', Common::num2percent(0, 2, true));
+        $this->assertEquals('-', Common::num2percent(1, 0, false));
+        $this->assertEquals('-', Common::num2percent(1, 0, true));
+        $this->assertEquals('-', Common::num2percent(0, 0, false));
+    }
 }


### PR DESCRIPTION
Adds a check for $cent == 0 before the percentage calculation to prevent a fatal division-by-zero when DB data is inconsistent.