### PR TITLE
fix: add error handling for json_decode in CommonReportMapper

### DIFF
--- a/classes/Database/Common/CommonReportMapper.php
+++ b/classes/Database/Common/CommonReportMapper.php
@@ -99,7 +99,7 @@ class CommonReportMapper implements ReportMapperInterface
             $data->loaded_time  = new DateTime($res[2]);
             $data->email        = $res[3];
             $data->extra_contact_info = $res[4];
-            $data->error_string = json_decode($res[5] ?? '', true);
+            $data->error_string = $this->jsonDecode($res[5] ?? '');
             $data->policy       = [
                 'adkim' => $res[6],
                 'aspf'  => $res[7],
@@ -124,9 +124,9 @@ class CommonReportMapper implements ReportMapperInterface
                     'ip'            => inet_ntop($res[1]),
                     'count'         => intval($res[2]),
                     'disposition'   => Common::$disposition[$res[3]],
-                    'reason'        => json_decode($res[4] ?? '', true),
-                    'dkim_auth'     => json_decode($res[5] ?? '', true),
-                    'spf_auth'      => json_decode($res[6] ?? '', true),
+                    'reason'        => $this->jsonDecode($res[4] ?? ''),
+                    'dkim_auth'     => $this->jsonDecode($res[5] ?? ''),
+                    'spf_auth'      => $this->jsonDecode($res[6] ?? ''),
                     'dkim_align'    => Common::$align_res[$res[7]],
                     'spf_align'     => Common::$align_res[$res[8]],
                     'envelope_to'   => $res[9],
@@ -894,5 +894,23 @@ class CommonReportMapper implements ReportMapperInterface
         foreach ($f_data[$filter_idx]['bindings'] as &$bv) {
             $st->bindValue(++$bind_pos, $bv[0], $bv[1]);
         }
+    }
+
+    /**
+     * Decodes a JSON string and throws on error
+     *
+     * @param string $json JSON string to decode
+     *
+     * @throws DatabaseFatalException
+     *
+     * @return mixed Decoded value
+     */
+    private function jsonDecode(string $json)
+    {
+        $res = json_decode($json, true);
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            throw new DatabaseFatalException('Failed to decode JSON data: ' . json_last_error_msg());
+        }
+        return $res;
     }
 }

--- a/classes/Database/Common/CommonReportMapper.php
+++ b/classes/Database/Common/CommonReportMapper.php
@@ -907,6 +907,11 @@ class CommonReportMapper implements ReportMapperInterface
      */
     private function jsonDecode(string $json)
     {
+        // empty string is not valid JSON, return null
+        if ($json == "") {
+            return null;
+        }
+
         $res = json_decode($json, true);
         if (json_last_error() !== JSON_ERROR_NONE) {
             throw new DatabaseFatalException('Failed to decode JSON data: ' . json_last_error_msg());

--- a/classes/Database/Common/CommonReportMapper.php
+++ b/classes/Database/Common/CommonReportMapper.php
@@ -897,13 +897,11 @@ class CommonReportMapper implements ReportMapperInterface
     }
 
     /**
-     * Decodes a JSON string and throws on error
+     * Decodes a JSON string and returns null on error
      *
      * @param string $json JSON string to decode
      *
-     * @throws DatabaseFatalException
-     *
-     * @return mixed Decoded value
+     * @return mixed Decoded value or null on failure
      */
     private function jsonDecode(string $json)
     {
@@ -914,7 +912,10 @@ class CommonReportMapper implements ReportMapperInterface
 
         $res = json_decode($json, true);
         if (json_last_error() !== JSON_ERROR_NONE) {
-            throw new DatabaseFatalException('Failed to decode JSON data: ' . json_last_error_msg());
+            if (Core::instance()->config('debug', 0)) {
+                Core::instance()->logger()->warning('Failed to decode JSON data: ' . json_last_error_msg());
+            }
+            return null;
         }
         return $res;
     }


### PR DESCRIPTION
Replaces bare json_decode calls with a private jsonDecode helper that checks json_last_error() and throws DatabaseFatalException on malformed JSON instead of silently returning null.