### PR TITLE
Add CSRF token protection for all state-changing POST endpoints

### DIFF
--- a/classes/Core.php
+++ b/classes/Core.php
@@ -271,6 +271,22 @@ class Core
     }
 
     /**
+     * Validates the X-CSRF-Token header against the session token pool.
+     *
+     * @throws SoftException
+     *
+     * @return void
+     */
+    public static function validateCsrf(): void
+    {
+        $token = $_SERVER['HTTP_X_CSRF_TOKEN'] ?? '';
+        $session = self::instance()->session();
+        if (!$session->validateCsrfToken($token)) {
+            throw new SoftException('CSRF token invalid', ErrorCodes::CSRF_INVALID);
+        }
+    }
+
+    /**
      * Checks if the dependencies passed in the parameter are installed
      *
      * @param string $deps Comma-separated string of dependency names to be checked

--- a/classes/ErrorCodes.php
+++ b/classes/ErrorCodes.php
@@ -52,6 +52,11 @@ class ErrorCodes
     public const DB_NOT_EMPTY = -4;
 
     /*
+     * CSRF token validation failed.
+     */
+    public const CSRF_INVALID = -5;
+
+    /*
      * Domain deletion error: there are incoming reports for the domain.
      */
     public const DOMAIN_HAS_REPORTS = -10;

--- a/classes/Session.php
+++ b/classes/Session.php
@@ -44,6 +44,8 @@ class Session
     private const LIFETIME_DURATION = 900;
     private const MIGRATE_DURATION  = 120;
     private const DATA_KEYS         = [ 'user', 's_id', 's_time' ];
+    private const CSRF_POOL_SIZE    = 2;
+    private const CSRF_KEY          = 'csrf_tokens';
 
     /**
      * Returns data of the session
@@ -225,5 +227,60 @@ class Session
             }
         }
         return $res;
+    }
+
+    /**
+     * Returns the current CSRF token, generating one if necessary.
+     *
+     * @return string
+     */
+    public function csrfToken(): string
+    {
+        if (!$this->isStarted()) {
+            $this->start();
+        }
+        if (empty($_SESSION[self::CSRF_KEY])) {
+            $_SESSION[self::CSRF_KEY] = [ $this->generateToken() ];
+        }
+        return $_SESSION[self::CSRF_KEY][0];
+    }
+
+    /**
+     * Validates a CSRF token against the pool and rotates on success.
+     *
+     * @param string $token Token to validate
+     *
+     * @return bool
+     */
+    public function validateCsrfToken(string $token): bool
+    {
+        if (!$this->isStarted()) {
+            $this->start();
+        }
+        if (empty($_SESSION[self::CSRF_KEY])) {
+            return false;
+        }
+        $pool = $_SESSION[self::CSRF_KEY];
+        if (!\in_array($token, $pool, true)) {
+            return false;
+        }
+        // Rotate: push new token, keep last N
+        $new_token = $this->generateToken();
+        array_unshift($pool, $new_token);
+        if (count($pool) > self::CSRF_POOL_SIZE) {
+            array_pop($pool);
+        }
+        $_SESSION[self::CSRF_KEY] = $pool;
+        return true;
+    }
+
+    /**
+     * Generates a cryptographically secure random token.
+     *
+     * @return string
+     */
+    private function generateToken(): string
+    {
+        return \bin2hex(\random_bytes(16));
     }
 }

--- a/public/admin.php
+++ b/public/admin.php
@@ -38,6 +38,7 @@ if (Core::isJson()) {
             Core::sendJson($core->admin()->state());
             return;
         } elseif (Core::requestMethod() == 'POST') {
+            Core::validateCsrf();
             $data = Core::getJsonData();
             if ($data) {
                 $cmd = $data['cmd'];
@@ -49,20 +50,25 @@ if (Core::isJson()) {
                         }
                     }
                 }
+                $csrf_token = Core::instance()->session()->csrfToken();
                 if ($cmd === 'initdb') {
-                    Core::sendJson($core->database()->initDb());
+                    $res = $core->database()->initDb();
+                    $res['csrf_token'] = $csrf_token;
+                    Core::sendJson($res);
                     return;
                 } elseif ($cmd === 'cleandb') {
-                    Core::sendJson($core->database()->cleanDb());
+                    $res = $core->database()->cleanDb();
+                    $res['csrf_token'] = $csrf_token;
+                    Core::sendJson($res);
                     return;
                 } elseif ($cmd === 'checksource') {
                     if (isset($data['id']) && isset($data['type'])) {
                         $id = $data['id'];
                         $type = $data['type'];
                         if (gettype($id) === 'integer' && gettype($type) === 'string') {
-                            Core::sendJson(
-                                $core->admin()->checkSource($id, $type)
-                            );
+                            $res = $core->admin()->checkSource($id, $type);
+                            $res['csrf_token'] = $csrf_token;
+                            Core::sendJson($res);
                             return;
                         }
                     }
@@ -72,7 +78,8 @@ if (Core::isJson()) {
                     Core::sendJson(
                         [
                             'error_code' => 0,
-                            'message'    => 'Upgraded successfully'
+                            'message'    => 'Upgraded successfully',
+                            'csrf_token' => $csrf_token
                         ]
                     );
                     return;

--- a/public/domains.php
+++ b/public/domains.php
@@ -94,6 +94,7 @@ if (Core::isJson()) {
             ]);
             return;
         } elseif (Core::requestMethod() == 'POST') {
+            Core::validateCsrf();
             $core = Core::instance();
             Core::instance()->auth()->isAllowed(User::LEVEL_MANAGER);
 
@@ -140,7 +141,8 @@ if (Core::isJson()) {
 
                 $res = [
                     'error_code' => 0,
-                    'message'    => 'Successfully'
+                    'message'    => 'Successfully',
+                    'csrf_token' => Core::instance()->session()->csrfToken()
                 ];
                 if (isset($domain)) {
                     $res['domain'] = $domain->toArray();

--- a/public/files.php
+++ b/public/files.php
@@ -143,6 +143,7 @@ if ($request->getMethod() === 'GET') {
 
 if ($request->getMethod() === 'POST') {
     try {
+        Core::validateCsrf();
         $core = Core::instance();
         if ($request->hasJsonData()) {
             $core->auth()->isAllowed(User::LEVEL_ADMIN);
@@ -169,7 +170,9 @@ if ($request->getMethod() === 'POST') {
             $core->checkDependencies('xml,zip');
 
             $results = (new ReportFetcher(new UploadedFilesSource($_FILES['report_file'])))->fetch();
-            Core::sendJson(ReportFetcher::makeSummaryResult($results));
+            $res = ReportFetcher::makeSummaryResult($results);
+            $res['csrf_token'] = Core::instance()->session()->csrfToken();
+            Core::sendJson($res);
             return;
         }
     } catch (RuntimeException $e) {

--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -106,6 +106,11 @@ class Admin {
 			if (!resp.ok)
 				throw new Error(`Failed to send command (${resp.status})`);
 			return resp.json();
+		}).then(function(data) {
+			if (data.csrf_token !== undefined) {
+				CsrfToken.set(data.csrf_token);
+			}
+			return data;
 		}).finally(function() {
 			t._get_admin_state();
 			Status.instance().update().catch(function(){});
@@ -405,6 +410,9 @@ class SourceListBox extends DropdownListBox {
 			return resp.json();
 		}).then(function(data) {
 			Common.checkResult(data);
+			if (data.csrf_token !== undefined) {
+				CsrfToken.set(data.csrf_token);
+			}
 			let msg = [ data.message ];
 			if (data.status) {
 				if (type === "mailbox") {

--- a/public/js/common.js
+++ b/public/js/common.js
@@ -23,8 +23,20 @@ const HTTP_HEADERS = {
 };
 
 const HTTP_HEADERS_POST = {
-	"Content-Type": "application/json"
+	"Content-Type": "application/json",
+	"X-CSRF-Token": ""
 };
+
+class CsrfToken {
+	static get() {
+		return this._value || "";
+	}
+
+	static set(value) {
+		this._value = value;
+		HTTP_HEADERS_POST["X-CSRF-Token"] = value;
+	}
+}
 
 function set_wait_status(el, text) {
 	const wait = document.createElement("div");

--- a/public/js/domains.js
+++ b/public/js/domains.js
@@ -442,6 +442,9 @@ class DomainEditDialog extends VerticalDialog {
 			return resp.json();
 		}).then(data => {
 			Common.checkResult(data);
+			if (data.csrf_token !== undefined) {
+				CsrfToken.set(data.csrf_token);
+			}
 			this._result = body;
 			this.hide();
 			Notification.add({
@@ -490,6 +493,9 @@ class DomainEditDialog extends VerticalDialog {
 			return resp.json();
 		}).then(data => {
 			Common.checkResult(data);
+			if (data.csrf_token !== undefined) {
+				CsrfToken.set(data.csrf_token);
+			}
 			this._result = data;
 			this.hide();
 			Notification.add({ text: "The domain " + body.fqdn + " was removed" });

--- a/public/js/files.js
+++ b/public/js/files.js
@@ -116,6 +116,7 @@ class Files {
 			window.fetch("files.php", {
 				method: "POST",
 				credentials: "same-origin",
+				headers: { "X-CSRF-Token": CsrfToken.get() },
 				body: new FormData(fm)
 			}).then(function(resp) {
 				if (!resp.ok)
@@ -123,6 +124,9 @@ class Files {
 				return resp.json();
 			}).then(function(data) {
 				Common.checkResult(data);
+				if (data.csrf_token !== undefined) {
+					CsrfToken.set(data.csrf_token);
+				}
 				Notification.add({ text: (data.message || "Uploaded successfully!"), type: "info" });
 				Status.instance().update().catch(() => {});
 			}).catch(function(err) {
@@ -207,6 +211,9 @@ class Files {
 					throw new Error("Failed to load report files");
 				return resp.json();
 			}).then(function(data) {
+				if (data.csrf_token !== undefined) {
+					CsrfToken.set(data.csrf_token);
+				}
 				if (!data.error_code) {
 					Notification.add({ text: (data.message || "Loaded successfully!"), type: "info" });
 				}

--- a/public/js/login.js
+++ b/public/js/login.js
@@ -86,6 +86,9 @@ class LoginDialog extends VerticalDialog {
 			return resp.json();
 		}).then(data => {
 			Common.checkResult(data);
+			if (data.csrf_token !== undefined) {
+				CsrfToken.set(data.csrf_token);
+			}
 			this._result = data;
 			Notification.add({ type: "info", text: data.message || "Successfully!", name: "auth" });
 			hide = true;

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -206,6 +206,9 @@ Router._update_menu = function(authenticated) {
 					return resp.json();
 				}).then(data => {
 					Common.checkResult(data);
+					if (data.csrf_token !== undefined) {
+						CsrfToken.set(data.csrf_token);
+					}
 					User.name = null;
 					User.level = null;
 					Status.instance().reset();

--- a/public/js/report.js
+++ b/public/js/report.js
@@ -280,6 +280,11 @@ class Report {
 			if (!resp.ok)
 				throw new Error("Failed to set report value");
 			return resp.json();
+		}).then(function(data) {
+			if (data && data.csrf_token !== undefined) {
+				CsrfToken.set(data.csrf_token);
+			}
+			return data;
 		}).catch(function(err) {
 			Common.displayError(err);
 		});

--- a/public/js/settings.js
+++ b/public/js/settings.js
@@ -324,6 +324,9 @@ class SettingEditDialog extends VerticalDialog {
 			return resp.json();
 		}).then(data => {
 			Common.checkResult(data);
+			if (data.csrf_token !== undefined) {
+				CsrfToken.set(data.csrf_token);
+			}
 			this._data.value = this._val_el.value;
 			this._result = body;
 			this.hide();

--- a/public/js/status.js
+++ b/public/js/status.js
@@ -64,6 +64,9 @@ class Status {
 			if (!resp.ok) throw new Error("Failed to fetch the status");
 			return resp.json();
 		}).then(function(data) {
+			if (data.csrf_token !== undefined) {
+				CsrfToken.set(data.csrf_token);
+			}
 			User.name  = data.user && data.user.name || null;
 			User.level = data.user && data.user.level || null;
 			User.auth_type = data.auth_type;

--- a/public/js/users.js
+++ b/public/js/users.js
@@ -476,6 +476,9 @@ class UserEditDialog extends VerticalDialog {
 			return resp.json();
 		}).then(data => {
 			Common.checkResult(data);
+			if (data.csrf_token !== undefined) {
+				CsrfToken.set(data.csrf_token);
+			}
 			this._result = body;
 			this.hide();
 			Notification.add({
@@ -510,6 +513,9 @@ class UserEditDialog extends VerticalDialog {
 			return resp.json();
 		}).then(data => {
 			Common.checkResult(data);
+			if (data.csrf_token !== undefined) {
+				CsrfToken.set(data.csrf_token);
+			}
 			this._result = data;
 			this.hide();
 			Notification.add({ text: `The user ${body.name} successfully removed` });
@@ -613,6 +619,9 @@ class PasswordDialog extends VerticalDialog {
 			return resp.json();
 		}).then(data => {
 			Common.checkResult(data);
+			if (data.csrf_token !== undefined) {
+				CsrfToken.set(data.csrf_token);
+			}
 			this._result = true;
 			this.hide();
 			Notification.add({ text: "The password has been successfully updated" });

--- a/public/login.php
+++ b/public/login.php
@@ -31,9 +31,10 @@ if (Core::requestMethod() == 'POST' && Core::isJson()) {
     $jdata = Core::getJsonData();
     if ($jdata && isset($jdata['password'])) {
         try {
-            Core::sendJson(
-                Core::instance()->auth()->login(strval($jdata['username'] ?? ''), strval($jdata['password']))
-            );
+            Core::validateCsrf();
+            $res = Core::instance()->auth()->login(strval($jdata['username'] ?? ''), strval($jdata['password']));
+            $res['csrf_token'] = Core::instance()->session()->csrfToken();
+            Core::sendJson($res);
         } catch (RuntimeException $e) {
             Core::sendJson(ErrorHandler::exceptionResult($e));
         }

--- a/public/logout.php
+++ b/public/logout.php
@@ -29,7 +29,10 @@ require realpath(__DIR__ . '/..') . '/init.php';
 
 if (Core::requestMethod() == 'POST' && Core::isJson()) {
     try {
-        Core::sendJson(Core::instance()->auth()->logout());
+        Core::validateCsrf();
+        $res = Core::instance()->auth()->logout();
+        $res['csrf_token'] = Core::instance()->session()->csrfToken();
+        Core::sendJson($res);
     } catch (RuntimeException $e) {
         Core::sendJson(ErrorHandler::exceptionResult($e));
     }

--- a/public/report.php
+++ b/public/report.php
@@ -64,6 +64,7 @@ if (!empty($_GET['org']) && !empty($_GET['time']) && !empty($_GET['domain']) && 
                 Core::sendJson([ 'report' => $rep->toArray() ]);
                 return;
             } elseif (Core::requestMethod() == 'POST') {
+                Core::validateCsrf();
                 if ($_GET['action'] === 'set') {
                     $jdata = Core::getJsonData();
                     if ($jdata && isset($jdata['name']) && isset($jdata['value'])) {
@@ -80,7 +81,9 @@ if (!empty($_GET['org']) && !empty($_GET['time']) && !empty($_GET['domain']) && 
                                 'report_id'  => $_GET['report_id']
                             ]
                         );
-                        Core::sendJson($rep->set($jdata['name'], $jdata['value']));
+                        $res = $rep->set($jdata['name'], $jdata['value']);
+                        $res['csrf_token'] = Core::instance()->session()->csrfToken();
+                        Core::sendJson($res);
                         return;
                     }
                 }

--- a/public/settings.php
+++ b/public/settings.php
@@ -84,6 +84,7 @@ if (Core::isJson()) {
         }
 
         if (Core::requestMethod() == 'POST') {
+            Core::validateCsrf();
             $data = Core::getJsonData();
             if ($data) {
                 $sett = SettingsList::getSettingByName($data['name'] ?? '');
@@ -94,7 +95,8 @@ if (Core::isJson()) {
                         $sett->save();
                         Core::sendJson([
                             'error_code' => 0,
-                            'message'    => 'Successfully updated'
+                            'message'    => 'Successfully updated',
+                            'csrf_token' => Core::instance()->session()->csrfToken()
                         ]);
                         break;
                     default:

--- a/public/status.php
+++ b/public/status.php
@@ -33,13 +33,14 @@ if (Core::isJson()) {
     if (Core::requestMethod() == 'GET') {
         try {
             $core = Core::instance();
+            $result = [
+                'csrf_token' => $core->session()->csrfToken()
+            ];
             $core->auth()->isAllowed(User::LEVEL_USER);
 
             $fields = explode(',', $_GET['fields'] ?? '');
             if (in_array('state', $fields)) {
-                $result = $core->status()->get();
-            } else {
-                $result = [];
+                $result = array_merge($result, $core->status()->get());
             }
 
             if (!($result['error_code'] ?? 0)) {

--- a/public/status.php
+++ b/public/status.php
@@ -31,13 +31,12 @@ require realpath(__DIR__ . '/..') . '/init.php';
 
 if (Core::isJson()) {
     if (Core::requestMethod() == 'GET') {
+        $core = Core::instance();
+        $csrf_token = $core->session()->csrfToken();
         try {
-            $core = Core::instance();
-            $result = [
-                'csrf_token' => $core->session()->csrfToken()
-            ];
             $core->auth()->isAllowed(User::LEVEL_USER);
 
+            $result = [ 'csrf_token' => $csrf_token ];
             $fields = explode(',', $_GET['fields'] ?? '');
             if (in_array('state', $fields)) {
                 $result = array_merge($result, $core->status()->get());
@@ -89,6 +88,7 @@ if (Core::isJson()) {
             Core::sendJson($result);
         } catch (RuntimeException $e) {
             $r = ErrorHandler::exceptionResult($e);
+            $r['csrf_token'] = $csrf_token;
             Core::sendJson($r);
         }
         return;

--- a/public/users.php
+++ b/public/users.php
@@ -119,6 +119,7 @@ if (Core::isJson()) {
             Core::sendJson($res);
             return;
         } elseif (Core::requestMethod() == 'POST') {
+            Core::validateCsrf();
             $data = Core::getJsonData();
             if ($data) {
                 $uname = $data['name'] ?? null;
@@ -144,7 +145,8 @@ if (Core::isJson()) {
                     $user->setPassword($data['new_password']);
                     Core::sendJson([
                         'error_code' => 0,
-                        'message'    => 'The password has been successfully updated'
+                        'message'    => 'The password has been successfully updated',
+                        'csrf_token' => Core::instance()->session()->csrfToken()
                     ]);
                     return;
                 }
@@ -196,7 +198,8 @@ if (Core::isJson()) {
 
                 $res = [
                     'error_code' => 0,
-                    'message'    => 'Successfully'
+                    'message'    => 'Successfully',
+                    'csrf_token' => Core::instance()->session()->csrfToken()
                 ];
                 if (isset($user)) {
                     $ua = $user->toArray();

--- a/tests/classes/CoreTest.php
+++ b/tests/classes/CoreTest.php
@@ -509,7 +509,6 @@ class CoreTest extends \PHPUnit\Framework\TestCase
     private function resetCoreInstance(): void
     {
         $ref = new \ReflectionProperty(Core::class, 'instance');
-        $ref->setAccessible(true);
         $ref->setValue(null, null);
     }
 

--- a/tests/classes/CoreTest.php
+++ b/tests/classes/CoreTest.php
@@ -456,6 +456,63 @@ class CoreTest extends \PHPUnit\Framework\TestCase
         unlink($lockFilePath);
     }
 
+    public function testValidateCsrfWithValidToken(): void
+    {
+        $sess = $this->getSessionMock([ 'validateCsrfToken' ]);
+        $sess->expects($this->once())
+             ->method('validateCsrfToken')
+             ->with('valid-token')
+             ->willReturn(true);
+
+        $this->resetCoreInstance();
+        new Core([ 'session' => $sess ]);
+
+        $_SERVER['HTTP_X_CSRF_TOKEN'] = 'valid-token';
+        Core::validateCsrf();
+        $this->assertTrue(true);
+    }
+
+    public function testValidateCsrfWithInvalidToken(): void
+    {
+        $sess = $this->getSessionMock([ 'validateCsrfToken' ]);
+        $sess->expects($this->once())
+             ->method('validateCsrfToken')
+             ->with('invalid-token')
+             ->willReturn(false);
+
+        $this->resetCoreInstance();
+        new Core([ 'session' => $sess ]);
+
+        $_SERVER['HTTP_X_CSRF_TOKEN'] = 'invalid-token';
+        $this->expectException(SoftException::class);
+        $this->expectExceptionMessage('CSRF token invalid');
+        Core::validateCsrf();
+    }
+
+    public function testValidateCsrfWithMissingHeader(): void
+    {
+        $sess = $this->getSessionMock([ 'validateCsrfToken' ]);
+        $sess->expects($this->once())
+             ->method('validateCsrfToken')
+             ->with('')
+             ->willReturn(false);
+
+        $this->resetCoreInstance();
+        new Core([ 'session' => $sess ]);
+
+        unset($_SERVER['HTTP_X_CSRF_TOKEN']);
+        $this->expectException(SoftException::class);
+        $this->expectExceptionMessage('CSRF token invalid');
+        Core::validateCsrf();
+    }
+
+    private function resetCoreInstance(): void
+    {
+        $ref = new \ReflectionProperty(Core::class, 'instance');
+        $ref->setAccessible(true);
+        $ref->setValue(null, null);
+    }
+
     private function getAuthEnabledMock()
     {
         $auth = $this->getMockBuilder(Auth::class)

--- a/tests/classes/SessionTest.php
+++ b/tests/classes/SessionTest.php
@@ -109,4 +109,61 @@ class SessionTest extends \PHPUnit\Framework\TestCase
         $this->sess->getData();
         $this->assertNotSame($fake_id, \session_id());
     }
+
+    public function testCsrfTokenGeneratesToken(): void
+    {
+        $token = $this->sess->csrfToken();
+        $this->assertNotEmpty($token);
+        $this->assertIsString($token);
+    }
+
+    public function testCsrfTokenReturnsSameToken(): void
+    {
+        $token1 = $this->sess->csrfToken();
+        $token2 = $this->sess->csrfToken();
+        $this->assertSame($token1, $token2);
+    }
+
+    public function testValidateCsrfTokenWithInvalidToken(): void
+    {
+        $this->sess->csrfToken();
+        $this->assertFalse($this->sess->validateCsrfToken('invalid-token'));
+    }
+
+    public function testValidateCsrfTokenWithValidToken(): void
+    {
+        $token = $this->sess->csrfToken();
+        $this->assertTrue($this->sess->validateCsrfToken($token));
+    }
+
+    public function testValidateCsrfTokenRotatesPool(): void
+    {
+        $token = $this->sess->csrfToken();
+        $this->assertTrue($this->sess->validateCsrfToken($token));
+        $new_token = $this->sess->csrfToken();
+        $this->assertNotSame($token, $new_token);
+    }
+
+    public function testCsrfTokenPoolSizeTwo(): void
+    {
+        $token1 = $this->sess->csrfToken();
+        // First validation rotates: pool now has 2 tokens
+        $this->assertTrue($this->sess->validateCsrfToken($token1));
+        // Old token is still valid because pool size is 2
+        $this->assertTrue($this->sess->validateCsrfToken($token1));
+    }
+
+    public function testCsrfTokenPoolRotationEvictsOldToken(): void
+    {
+        $token1 = $this->sess->csrfToken();
+        $this->assertTrue($this->sess->validateCsrfToken($token1));
+        $token2 = $this->sess->csrfToken();
+        $this->assertTrue($this->sess->validateCsrfToken($token2));
+        $token3 = $this->sess->csrfToken();
+        // token1 should now be evicted from pool (size 2)
+        $this->assertFalse($this->sess->validateCsrfToken($token1));
+        // token2 and token3 should still be valid
+        $this->assertTrue($this->sess->validateCsrfToken($token2));
+        $this->assertTrue($this->sess->validateCsrfToken($token3));
+    }
 }


### PR DESCRIPTION
Implements synchronizer-token CSRF protection across the application. A per-session rotating CSRF token is generated, exposed via status.php, and validated on all state-changing POST requests. The frontend automatically injects the token into POST headers and refreshes it from each response.

### Backend changes

- **`classes/ErrorCodes.php`**: Added `CSRF_INVALID = -5`
- **`classes/Session.php`**: Added `csrfToken()` and `validateCsrfToken()` with a 2-token pool for rotation and concurrency tolerance
- **`classes/Core.php`**: Added `validateCsrf()` helper that reads the `X-CSRF-Token` header and throws `SoftException` on mismatch
- **public/status.php**: Returns `csrf_token` unconditionally in GET responses - **even before authentication**- so unauthenticated clients can obtain a token for login/logout protection
- **All POST endpoints** (`login.php`, `logout.php`, `admin.php`, `domains.php`, `files.php`, `users.php`, `settings.php`, `report.php`): Added `Core::validateCsrf()` and return a fresh `csrf_token` in successful JSON responses

### Frontend changes

- **public/js/common.js**: Added global [CsrfToken](cci:2://file:///home/stefan/github/dmarc-srg/public/js/common.js:29:0-38:1) class; `HTTP_HEADERS_POST` now includes `X-CSRF-Token`
- **public/js/status.js**: Extracts and stores the initial token from status.php
- **All POST fetch() handlers** (login, logout, admin, domains, files, users, settings, report): Refresh CsrfToken from response data
- **public/js/files.js**: Multipart upload explicitly sends `X-CSRF-Token` header

### Design notes

- **2-token pool**: tolerates concurrent requests using the same token
- **Per-request rotation**: each validated POST generates a new token
- **Login/logout protected**: token is available before authentication
- **Dedicated error code `-5`**: for CSRF validation failures