### PR TITLE
Add configurable max decompressed size limit for DMARC report files

### DIFF
--- a/classes/Report/Report.php
+++ b/classes/Report/Report.php
@@ -47,9 +47,9 @@ class Report
         $this->db   = $db ?? Core::instance()->database();
     }
 
-    public static function fromXmlFile($fd)
+    public static function fromXmlFile($fd, ?int $maxSize = null)
     {
-        $data = ReportData::fromXmlFile($fd);
+        $data = ReportData::fromXmlFile($fd, false, $maxSize);
         if (!$data->isValid()) {
             throw new SoftException('Incorrect or incomplete report data');
         }

--- a/classes/Report/Report.php
+++ b/classes/Report/Report.php
@@ -47,7 +47,7 @@ class Report
         $this->db   = $db ?? Core::instance()->database();
     }
 
-    public static function fromXmlFile($fd, ?int $maxSize = null)
+    public static function fromXmlFile($fd, int $maxSize = PHP_INT_MAX)
     {
         $data = ReportData::fromXmlFile($fd, false, $maxSize);
         if (!$data->isValid()) {

--- a/classes/Report/ReportData.php
+++ b/classes/Report/ReportData.php
@@ -58,7 +58,7 @@ class ReportData
         return $rdata;
     }
 
-    public static function fromXmlFile($fd, $strict = false, ?int $maxSize = null)
+    public static function fromXmlFile($fd, $strict = false, int $maxSize = PHP_INT_MAX)
     {
         $rdata = new self($strict);
         $rdata->tag_id = '<root>';
@@ -74,7 +74,7 @@ class ReportData
         try {
             while ($file_data = fread($fd, 4096)) {
                 $total += strlen($file_data);
-                if ($maxSize !== null && $total > $maxSize) {
+                if ($total > $maxSize) {
                     throw new SoftException('Report file is too large after decompression');
                 }
                 if (!xml_parse($parser, $file_data, feof($fd))) {

--- a/classes/Report/ReportData.php
+++ b/classes/Report/ReportData.php
@@ -24,6 +24,7 @@ namespace Liuch\DmarcSrg\Report;
 
 use Liuch\DmarcSrg\DateTime;
 use Liuch\DmarcSrg\Exception\RuntimeException;
+use Liuch\DmarcSrg\Exception\SoftException;
 
 class ReportData
 {
@@ -57,7 +58,7 @@ class ReportData
         return $rdata;
     }
 
-    public static function fromXmlFile($fd, $strict = false)
+    public static function fromXmlFile($fd, $strict = false, ?int $maxSize = null)
     {
         $rdata = new self($strict);
         $rdata->tag_id = '<root>';
@@ -69,8 +70,13 @@ class ReportData
         xml_set_external_entity_ref_handler($parser, function () {
             throw new RuntimeException('The XML document has an external entity!');
         });
+        $total = 0;
         try {
             while ($file_data = fread($fd, 4096)) {
+                $total += strlen($file_data);
+                if ($maxSize !== null && $total > $maxSize) {
+                    throw new SoftException('Report file is too large after decompression');
+                }
                 if (!xml_parse($parser, $file_data, feof($fd))) {
                     $pc = xml_get_error_code($parser);
                     $error_str  = 'XML error!' . PHP_EOL;

--- a/classes/Report/ReportFetcher.php
+++ b/classes/Report/ReportFetcher.php
@@ -97,6 +97,7 @@ class ReportFetcher
             default:
                 throw new RuntimeException('Unknown source type');
         }
+        $maxSize = $core->config('fetcher/max_report_size', 10485760);
         $limit = intval($limit);
         if ($stype === Source::SOURCE_MAILBOX ||
             $stype === Source::SOURCE_DIRECTORY ||
@@ -120,7 +121,7 @@ class ReportFetcher
             try {
                 $rfile   = $this->source->current();
                 $fname   = $rfile->filename();
-                $report  = Report::fromXmlFile($rfile->datastream());
+                $report  = Report::fromXmlFile($rfile->datastream($maxSize), $maxSize);
                 $result  = $report->save($fname);
                 $success = true;
             } catch (RuntimeException $e) {

--- a/classes/ReportFile/ReportFile.php
+++ b/classes/ReportFile/ReportFile.php
@@ -131,7 +131,7 @@ class ReportFile
         return $this->filename;
     }
 
-    public function datastream(?int $maxSize = null)
+    public function datastream(int $maxSize = PHP_INT_MAX)
     {
         if (!$this->fd) {
             $fd = null;
@@ -146,11 +146,9 @@ class ReportFile
                     if ($zfn !== pathinfo($zfn, PATHINFO_BASENAME)) {
                         throw new SoftException('There must not be any directories in the archive');
                     }
-                    if ($maxSize !== null) {
-                        $zstat = $this->zip->statIndex(0);
-                        if ($zstat !== false && $zstat['size'] > $maxSize) {
-                            throw new SoftException('Uncompressed ZIP entry exceeds size limit');
-                        }
+                    $zstat = $this->zip->statIndex(0);
+                    if ($zstat !== false && $zstat['size'] > $maxSize) {
+                        throw new SoftException('Uncompressed ZIP entry exceeds size limit');
                     }
                     $fd = $this->zip->getStream($zfn);
                     break;

--- a/classes/ReportFile/ReportFile.php
+++ b/classes/ReportFile/ReportFile.php
@@ -131,7 +131,7 @@ class ReportFile
         return $this->filename;
     }
 
-    public function datastream()
+    public function datastream(?int $maxSize = null)
     {
         if (!$this->fd) {
             $fd = null;
@@ -145,6 +145,12 @@ class ReportFile
                     $zfn = $this->zip->getNameIndex(0);
                     if ($zfn !== pathinfo($zfn, PATHINFO_BASENAME)) {
                         throw new SoftException('There must not be any directories in the archive');
+                    }
+                    if ($maxSize !== null) {
+                        $zstat = $this->zip->statIndex(0);
+                        if ($zstat !== false && $zstat['size'] > $maxSize) {
+                            throw new SoftException('Uncompressed ZIP entry exceeds size limit');
+                        }
                     }
                     $fd = $this->zip->getStream($zfn);
                     break;

--- a/config/conf.sample.php
+++ b/config/conf.sample.php
@@ -212,6 +212,13 @@ $fetcher = [
      *   '.+\\.example\\.net$'  - Matches any subdomain of the domain example.net
      *   '^mymail[0-9]+\\.net$' - Matches the domains mymail01.net, mymail02.net, mymail99999.net, etc.
      */
+    /**
+     * Maximum size of a decompressed DMARC report file in bytes.
+     * Reports that exceed this limit after decompression will be rejected.
+     * The default value is 10 MB (10485760 bytes).
+     */
+    'max_report_size' => 10485760,
+
     'allowed_domains' => '',
 
     /**

--- a/tests/classes/Report/ReportDataTest.php
+++ b/tests/classes/Report/ReportDataTest.php
@@ -45,12 +45,18 @@ class ReportDataTest extends \PHPUnit\Framework\TestCase
             . '</feedback>';
     }
 
-    public function testFromXmlFileValid(): void
+    private static function xmlToStream(string $xml)
     {
-        $xml = self::minimalValidXml();
         $fd = fopen('php://memory', 'r+');
         fwrite($fd, $xml);
         rewind($fd);
+        return $fd;
+    }
+
+    public function testFromXmlFileValid(): void
+    {
+        $xml = self::minimalValidXml();
+        $fd = self::xmlToStream($xml);
 
         $data = ReportData::fromXmlFile($fd);
         fclose($fd);
@@ -61,9 +67,7 @@ class ReportDataTest extends \PHPUnit\Framework\TestCase
     public function testFromXmlFileUnderLimit(): void
     {
         $xml = self::minimalValidXml();
-        $fd = fopen('php://memory', 'r+');
-        fwrite($fd, $xml);
-        rewind($fd);
+        $fd = self::xmlToStream($xml);
 
         $data = ReportData::fromXmlFile($fd, false, 1024 * 1024);
         fclose($fd);
@@ -74,9 +78,7 @@ class ReportDataTest extends \PHPUnit\Framework\TestCase
     public function testFromXmlFileExceedsLimit(): void
     {
         $xml = self::minimalValidXml();
-        $fd = fopen('php://memory', 'r+');
-        fwrite($fd, $xml);
-        rewind($fd);
+        $fd = self::xmlToStream($xml);
 
         $this->expectException(SoftException::class);
         $this->expectExceptionMessage('Report file is too large after decompression');
@@ -87,11 +89,9 @@ class ReportDataTest extends \PHPUnit\Framework\TestCase
     public function testFromXmlFileNoLimit(): void
     {
         $xml = self::minimalValidXml();
-        $fd = fopen('php://memory', 'r+');
-        fwrite($fd, $xml);
-        rewind($fd);
+        $fd = self::xmlToStream($xml);
 
-        $data = ReportData::fromXmlFile($fd, false, null);
+        $data = ReportData::fromXmlFile($fd);
         fclose($fd);
 
         $this->assertTrue($data->isValid());

--- a/tests/classes/Report/ReportDataTest.php
+++ b/tests/classes/Report/ReportDataTest.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Liuch\DmarcSrg\Report;
+
+use Liuch\DmarcSrg\Exception\SoftException;
+
+class ReportDataTest extends \PHPUnit\Framework\TestCase
+{
+    private static function minimalValidXml(): string
+    {
+        return '<?xml version="1.0" encoding="UTF-8" ?>'
+            . '<feedback>'
+            . '<report_metadata>'
+            . '<org_name>Example Org</org_name>'
+            . '<email>postmaster@example.com</email>'
+            . '<report_id>12345</report_id>'
+            . '<date_range><begin>1609459200</begin><end>1609545600</end></date_range>'
+            . '</report_metadata>'
+            . '<policy_published>'
+            . '<domain>example.com</domain>'
+            . '<adkim>r</adkim>'
+            . '<aspf>r</aspf>'
+            . '<p>none</p>'
+            . '<sp>none</sp>'
+            . '<pct>100</pct>'
+            . '</policy_published>'
+            . '<record>'
+            . '<row>'
+            . '<source_ip>192.0.2.1</source_ip>'
+            . '<count>1</count>'
+            . '<policy_evaluated>'
+            . '<disposition>none</disposition>'
+            . '<dkim>pass</dkim>'
+            . '<spf>pass</spf>'
+            . '</policy_evaluated>'
+            . '</row>'
+            . '<identifiers>'
+            . '<header_from>example.com</header_from>'
+            . '</identifiers>'
+            . '<auth_results>'
+            . '<dkim><domain>example.com</domain><result>pass</result></dkim>'
+            . '<spf><domain>example.com</domain><result>pass</result></spf>'
+            . '</auth_results>'
+            . '</record>'
+            . '</feedback>';
+    }
+
+    public function testFromXmlFileValid(): void
+    {
+        $xml = self::minimalValidXml();
+        $fd = fopen('php://memory', 'r+');
+        fwrite($fd, $xml);
+        rewind($fd);
+
+        $data = ReportData::fromXmlFile($fd);
+        fclose($fd);
+
+        $this->assertTrue($data->isValid());
+    }
+
+    public function testFromXmlFileUnderLimit(): void
+    {
+        $xml = self::minimalValidXml();
+        $fd = fopen('php://memory', 'r+');
+        fwrite($fd, $xml);
+        rewind($fd);
+
+        $data = ReportData::fromXmlFile($fd, false, 1024 * 1024);
+        fclose($fd);
+
+        $this->assertTrue($data->isValid());
+    }
+
+    public function testFromXmlFileExceedsLimit(): void
+    {
+        $xml = self::minimalValidXml();
+        $fd = fopen('php://memory', 'r+');
+        fwrite($fd, $xml);
+        rewind($fd);
+
+        $this->expectException(SoftException::class);
+        $this->expectExceptionMessage('Report file is too large after decompression');
+
+        ReportData::fromXmlFile($fd, false, strlen($xml) - 1);
+    }
+
+    public function testFromXmlFileNoLimit(): void
+    {
+        $xml = self::minimalValidXml();
+        $fd = fopen('php://memory', 'r+');
+        fwrite($fd, $xml);
+        rewind($fd);
+
+        $data = ReportData::fromXmlFile($fd, false, null);
+        fclose($fd);
+
+        $this->assertTrue($data->isValid());
+    }
+}

--- a/tests/classes/ReportFile/ReportFileTest.php
+++ b/tests/classes/ReportFile/ReportFileTest.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace Liuch\DmarcSrg\ReportFile;
+
+use Liuch\DmarcSrg\Exception\SoftException;
+
+class ReportFileTest extends \PHPUnit\Framework\TestCase
+{
+    private static function minimalValidXml(): string
+    {
+        return '<?xml version="1.0" encoding="UTF-8" ?>'
+            . '<feedback>'
+            . '<report_metadata>'
+            . '<org_name>Example Org</org_name>'
+            . '<email>postmaster@example.com</email>'
+            . '<report_id>12345</report_id>'
+            . '<date_range><begin>1609459200</begin><end>1609545600</end></date_range>'
+            . '</report_metadata>'
+            . '<policy_published>'
+            . '<domain>example.com</domain>'
+            . '<adkim>r</adkim>'
+            . '<aspf>r</aspf>'
+            . '<p>none</p>'
+            . '<sp>none</sp>'
+            . '<pct>100</pct>'
+            . '</policy_published>'
+            . '<record>'
+            . '<row>'
+            . '<source_ip>192.0.2.1</source_ip>'
+            . '<count>1</count>'
+            . '<policy_evaluated>'
+            . '<disposition>none</disposition>'
+            . '<dkim>pass</dkim>'
+            . '<spf>pass</spf>'
+            . '</policy_evaluated>'
+            . '</row>'
+            . '<identifiers>'
+            . '<header_from>example.com</header_from>'
+            . '</identifiers>'
+            . '<auth_results>'
+            . '<dkim><domain>example.com</domain><result>pass</result></dkim>'
+            . '<spf><domain>example.com</domain><result>pass</result></spf>'
+            . '</auth_results>'
+            . '</record>'
+            . '</feedback>';
+    }
+
+    private static function createTempZip(string $content, string $entryName = 'report.xml'): string
+    {
+        $tmpPath = tempnam(sys_get_temp_dir(), 'dmarc_test_');
+        $zip = new \ZipArchive();
+        if ($zip->open($tmpPath, \ZipArchive::CREATE | \ZipArchive::OVERWRITE) !== true) {
+            throw new \RuntimeException('Failed to create temporary ZIP file');
+        }
+        $zip->addFromString($entryName, $content);
+        $zip->close();
+        return $tmpPath;
+    }
+
+    private static function createTempGz(string $content): string
+    {
+        $tmpPath = tempnam(sys_get_temp_dir(), 'dmarc_test_');
+        $gz = gzopen($tmpPath, 'w');
+        gzwrite($gz, $content);
+        gzclose($gz);
+        return $tmpPath;
+    }
+
+    public function testDatastreamZipUnderLimit(): void
+    {
+        $xml = self::minimalValidXml();
+        $zipPath = self::createTempZip($xml);
+        $reportFile = ReportFile::fromFile($zipPath, 'report.zip', true);
+
+        $fd = $reportFile->datastream(strlen($xml));
+        $this->assertIsResource($fd);
+
+        unset($reportFile);
+    }
+
+    public function testDatastreamZipExceedsLimit(): void
+    {
+        $xml = self::minimalValidXml();
+        $zipPath = self::createTempZip($xml);
+        $reportFile = ReportFile::fromFile($zipPath, 'report.zip', true);
+
+        $this->expectException(SoftException::class);
+        $this->expectExceptionMessage('Uncompressed ZIP entry exceeds size limit');
+
+        $reportFile->datastream(strlen($xml) - 1);
+    }
+
+    public function testDatastreamZipNoLimit(): void
+    {
+        $xml = self::minimalValidXml();
+        $zipPath = self::createTempZip($xml);
+        $reportFile = ReportFile::fromFile($zipPath, 'report.zip', true);
+
+        $fd = $reportFile->datastream(null);
+        $this->assertIsResource($fd);
+
+        unset($reportFile);
+    }
+
+    public function testDatastreamGzipUnderLimit(): void
+    {
+        $xml = self::minimalValidXml();
+        $gzPath = self::createTempGz($xml);
+        $reportFile = ReportFile::fromFile($gzPath, 'report.xml.gz', true);
+
+        $fd = $reportFile->datastream(strlen($xml));
+        $this->assertIsResource($fd);
+
+        unset($reportFile);
+    }
+}

--- a/tests/classes/ReportFile/ReportFileTest.php
+++ b/tests/classes/ReportFile/ReportFileTest.php
@@ -96,7 +96,7 @@ class ReportFileTest extends \PHPUnit\Framework\TestCase
         $zipPath = self::createTempZip($xml);
         $reportFile = ReportFile::fromFile($zipPath, 'report.zip', true);
 
-        $fd = $reportFile->datastream(null);
+        $fd = $reportFile->datastream();
         $this->assertIsResource($fd);
 
         unset($reportFile);


### PR DESCRIPTION
The attachment compressed size is capped at 1 MB in `MailMessage::validate()` (line 50), but there is no limit on how many bytes are read after decompression. `ReportData::fromXmlFile()` reads the decompressed stream in an unbounded loop:
```php
  // ReportData.php:73 — no byte counter, no limit
  while ($file_data = fread($fd, 4096)) {
      xml_parse($parser, $file_data, feof($fd));
  }
```
For ZIP: `ZipArchive::getStream()` streams decompressed data lazily - the compressed size passes the 1 MB check, but the expanded stream is unlimited. For gzip: same via zlib.inflate stream filter. A well-formed 1 MB zip bomb (e.g. `zbsm.gz`) can expand to ~1 GB.

- Add `fetcher/max_report_size` config option (default 10 MB)
- Add ZIP pre-check via `ZipArchive::statIndex(0)['size']` before streaming
- Add streaming byte counter in `ReportData::fromXmlFile()` fread loop
- Wire limit through `Report::fromXmlFile()` and ReportFetcher
- Add unit tests for ZIP pre-check and streaming limit behavior