### PR TITLE
Fix base64_decode without strict mode in MailAttachment::toString()

### DIFF
--- a/classes/Mail/PhpExtension/MailAttachment.php
+++ b/classes/Mail/PhpExtension/MailAttachment.php
@@ -99,9 +99,17 @@ class MailAttachment extends \Liuch\DmarcSrg\Mail\MailAttachment
             case ENCBINARY:
                 return $this->fetchBody();
             case ENCBASE64:
-                return base64_decode($this->fetchBody());
+                $decoded = base64_decode($this->fetchBody(), true);
+                if ($decoded === false) {
+                    throw new SoftException('Failed to decode base64 attachment');
+                }
+                return $decoded;
             case ENCQUOTEDPRINTABLE:
-                return imap_qprint($this->fetchBody());
+                $decoded = imap_qprint($this->fetchBody());
+                if ($decoded === false) {
+                    throw new SoftException('Failed to decode quoted-printable attachment');
+                }
+                return $decoded;
         }
         throw new SoftException('Encoding failed: Unknown encoding');
     }

--- a/tests/classes/Mail/PhpExtension/MailAttachmentTest.php
+++ b/tests/classes/Mail/PhpExtension/MailAttachmentTest.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Liuch\DmarcSrg\Mail\PhpExtension;
+
+function imap_fetchbody($stream, $msg_num, $part_num, $options = 0)
+{
+    return \Liuch\DmarcSrg\MailAttachmentTest::$bodyContent;
+}
+
+function imap_qprint($string)
+{
+    return \Liuch\DmarcSrg\MailAttachmentTest::$qprintResult;
+}
+
+namespace Liuch\DmarcSrg;
+
+use Liuch\DmarcSrg\Mail\PhpExtension\MailAttachment;
+use Liuch\DmarcSrg\Exception\SoftException;
+
+class MailAttachmentTest extends \PHPUnit\Framework\TestCase
+{
+    public static $bodyContent = '';
+    public static $qprintResult = '';
+
+    public function testBase64DecodeFailure(): void
+    {
+        MailAttachmentTest::$bodyContent = 'not-valid-base64!!!';
+
+        $mailbox = new class {
+            public function connection()
+            {
+                return null;
+            }
+        };
+
+        $attachment = new MailAttachment([
+            'mailbox'  => $mailbox,
+            'filename' => 'test.xml',
+            'bytes'    => 100,
+            'number'   => 1,
+            'mnumber'  => 1,
+            'encoding' => \ENCBASE64,
+        ]);
+
+        $this->expectException(SoftException::class);
+        $this->expectExceptionMessage('Failed to decode base64 attachment');
+        $attachment->datastream();
+    }
+
+    public function testQuotedPrintableDecodeFailure(): void
+    {
+        MailAttachmentTest::$bodyContent = 'some content';
+        MailAttachmentTest::$qprintResult = false;
+
+        $mailbox = new class {
+            public function connection()
+            {
+                return null;
+            }
+        };
+
+        $attachment = new MailAttachment([
+            'mailbox'  => $mailbox,
+            'filename' => 'test.xml',
+            'bytes'    => 100,
+            'number'   => 1,
+            'mnumber'  => 1,
+            'encoding' => \ENCQUOTEDPRINTABLE,
+        ]);
+
+        $this->expectException(SoftException::class);
+        $this->expectExceptionMessage('Failed to decode quoted-printable attachment');
+        $attachment->datastream();
+    }
+}


### PR DESCRIPTION
- Use strict mode (base64_decode(..., true)) and throw SoftException on failure.
- Also add error handling for imap_qprint, which silently returns false on failure.
- Add regression tests for both ENCBASE64 and ENCQUOTEDPRINTABLE decode failures.