### PR TITLE
MIME Type Trusted from Email Header

### DIFF
--- a/classes/Mail/ImapEngine/MailAttachment.php
+++ b/classes/Mail/ImapEngine/MailAttachment.php
@@ -46,10 +46,7 @@ class MailAttachment extends \Liuch\DmarcSrg\Mail\MailAttachment
     public function mimeType(): string
     {
         if (is_null($this->mime_type)) {
-            $this->mime_type = $this->attachment->contentType();
-            if ($this->mime_type === 'application/octet-stream') {
-                $this->mime_type = ReportFile::getMimeType($this->attachment->filename(), $this->datastream());
-            }
+            $this->mime_type = ReportFile::getMimeType($this->attachment->filename(), $this->datastream());
         }
         return $this->mime_type;
     }

--- a/classes/Mail/ImapEngine/MailAttachment.php
+++ b/classes/Mail/ImapEngine/MailAttachment.php
@@ -22,6 +22,7 @@
 
 namespace Liuch\DmarcSrg\Mail\ImapEngine;
 
+use Liuch\DmarcSrg\Exception\SoftException;
 use Liuch\DmarcSrg\ReportFile\ReportFile;
 
 class MailAttachment extends \Liuch\DmarcSrg\Mail\MailAttachment
@@ -46,7 +47,19 @@ class MailAttachment extends \Liuch\DmarcSrg\Mail\MailAttachment
     public function mimeType(): string
     {
         if (is_null($this->mime_type)) {
-            $this->mime_type = ReportFile::getMimeType($this->attachment->filename(), $this->datastream());
+            $header_type = $this->attachment->contentType();
+            $actual_type = ReportFile::getMimeType($this->attachment->filename(), $this->datastream());
+
+            $header_type = $header_type === 'application/x-gzip' ? 'application/gzip' : $header_type;
+            $actual_type = $actual_type === 'application/x-gzip' ? 'application/gzip' : $actual_type;
+
+            if ($header_type === 'application/octet-stream') {
+                $this->mime_type = $actual_type;
+            } elseif ($header_type === $actual_type) {
+                $this->mime_type = $actual_type;
+            } else {
+                throw new SoftException("Attachment MIME type mismatch: header says '{$header_type}' but actual content is '{$actual_type}'");
+            }
         }
         return $this->mime_type;
     }

--- a/classes/Mail/PhpExtension/MailAttachment.php
+++ b/classes/Mail/PhpExtension/MailAttachment.php
@@ -36,17 +36,19 @@ class MailAttachment extends \Liuch\DmarcSrg\Mail\MailAttachment
     private $encoding;
     private $stream;
     private $mime_type;
+    private $header_mime_type;
 
     public function __construct($data)
     {
-        $this->mailbox  = $data['mailbox'];
-        $this->filename = $data['filename'];
-        $this->bytes    = $data['bytes'];
-        $this->number   = $data['number'];
-        $this->mnumber  = $data['mnumber'];
-        $this->encoding = $data['encoding'];
-        $this->stream    = null;
-        $this->mime_type = null;
+        $this->mailbox          = $data['mailbox'];
+        $this->filename         = $data['filename'];
+        $this->bytes            = $data['bytes'];
+        $this->number           = $data['number'];
+        $this->mnumber          = $data['mnumber'];
+        $this->encoding         = $data['encoding'];
+        $this->header_mime_type = $data['header_mime_type'];
+        $this->stream           = null;
+        $this->mime_type        = null;
     }
 
     public function __destruct()
@@ -59,7 +61,18 @@ class MailAttachment extends \Liuch\DmarcSrg\Mail\MailAttachment
     public function mimeType(): string
     {
         if (is_null($this->mime_type)) {
-            $this->mime_type = ReportFile::getMimeType($this->filename, $this->datastream());
+            $actual_type = ReportFile::getMimeType($this->filename, $this->datastream());
+
+            $header_type = $this->header_mime_type === 'application/x-gzip' ? 'application/gzip' : $this->header_mime_type;
+            $actual_type = $actual_type === 'application/x-gzip' ? 'application/gzip' : $actual_type;
+
+            if ($header_type === 'application/octet-stream') {
+                $this->mime_type = $actual_type;
+            } elseif ($header_type === $actual_type) {
+                $this->mime_type = $actual_type;
+            } else {
+                throw new SoftException("Attachment MIME type mismatch: header says '{$header_type}' but actual content is '{$actual_type}'");
+            }
         }
         return $this->mime_type;
     }

--- a/classes/Mail/PhpExtension/MailMessage.php
+++ b/classes/Mail/PhpExtension/MailMessage.php
@@ -188,12 +188,26 @@ class MailMessage extends \Liuch\DmarcSrg\Mail\MailMessage
             return null;
         }
 
+        $type_map = [
+            TYPETEXT        => 'text',
+            TYPEMULTIPART   => 'multipart',
+            TYPEMESSAGE     => 'message',
+            TYPEAPPLICATION => 'application',
+            TYPEAUDIO       => 'audio',
+            TYPEIMAGE       => 'image',
+            TYPEVIDEO       => 'video',
+            TYPEOTHER       => 'other',
+        ];
+        $type_str = $type_map[$part->type] ?? 'application';
+        $subtype  = strtolower((string) ($part->subtype ?? 'octet-stream'));
+
         return [
-            'filename' => imap_utf8($filename),
-            'bytes'    => isset($part->bytes) ? $part->bytes : -1,
-            'number'   => $parNbr,
-            'mnumber'  => $this->number,
-            'encoding' => $part->encoding
+            'filename'         => imap_utf8($filename),
+            'bytes'            => isset($part->bytes) ? $part->bytes : -1,
+            'number'           => $parNbr,
+            'mnumber'          => $this->number,
+            'encoding'         => $part->encoding,
+            'header_mime_type' => $type_str . '/' . $subtype,
         ];
     }
 

--- a/tests/classes/Mail/ImapEngine/MailAttachmentTest.php
+++ b/tests/classes/Mail/ImapEngine/MailAttachmentTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Liuch\DmarcSrg\Mail\ImapEngine;
+
+use GuzzleHttp\Psr7\Utils;
+use PHPUnit\Framework\TestCase;
+
+class MailAttachmentTest extends TestCase
+{
+    public function testMimeTypeIgnoresEmailHeader(): void
+    {
+        // gzip magic bytes followed by dummy payload
+        $gzipContent = "\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\x03" . str_repeat("\x00", 20);
+
+        $mockAttachment = new class ($gzipContent) {
+            private $content;
+            public function __construct(string $content)
+            {
+                $this->content = $content;
+            }
+            public function contentType(): string
+            {
+                return 'text/xml';
+            }
+            public function filename(): string
+            {
+                return 'report.xml.gz';
+            }
+            public function contentStream()
+            {
+                return Utils::streamFor($this->content);
+            }
+        };
+
+        $mailAttachment = new MailAttachment($mockAttachment);
+
+        // Must not trust the attacker-controlled Content-Type header
+        $this->assertNotSame('text/xml', $mailAttachment->mimeType());
+    }
+}

--- a/tests/classes/Mail/ImapEngine/MailAttachmentTest.php
+++ b/tests/classes/Mail/ImapEngine/MailAttachmentTest.php
@@ -4,10 +4,11 @@ namespace Liuch\DmarcSrg\Mail\ImapEngine;
 
 use GuzzleHttp\Psr7\Utils;
 use PHPUnit\Framework\TestCase;
+use Liuch\DmarcSrg\Exception\SoftException;
 
 class MailAttachmentTest extends TestCase
 {
-    public function testMimeTypeIgnoresEmailHeader(): void
+    public function testMimeTypeRejectsMismatchedHeader(): void
     {
         // gzip magic bytes followed by dummy payload
         $gzipContent = "\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\x03" . str_repeat("\x00", 20);
@@ -34,7 +35,65 @@ class MailAttachmentTest extends TestCase
 
         $mailAttachment = new MailAttachment($mockAttachment);
 
-        // Must not trust the attacker-controlled Content-Type header
-        $this->assertNotSame('text/xml', $mailAttachment->mimeType());
+        $this->expectException(SoftException::class);
+        $mailAttachment->mimeType();
+    }
+
+    public function testMimeTypeAcceptsMatchingHeader(): void
+    {
+        $gzipContent = "\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\x03" . str_repeat("\x00", 20);
+
+        $mockAttachment = new class ($gzipContent) {
+            private $content;
+            public function __construct(string $content)
+            {
+                $this->content = $content;
+            }
+            public function contentType(): string
+            {
+                return 'application/gzip';
+            }
+            public function filename(): string
+            {
+                return 'report.xml.gz';
+            }
+            public function contentStream()
+            {
+                return Utils::streamFor($this->content);
+            }
+        };
+
+        $mailAttachment = new MailAttachment($mockAttachment);
+
+        $this->assertSame('application/gzip', $mailAttachment->mimeType());
+    }
+
+    public function testMimeTypeFallsBackForOctetStream(): void
+    {
+        $gzipContent = "\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\x03" . str_repeat("\x00", 20);
+
+        $mockAttachment = new class ($gzipContent) {
+            private $content;
+            public function __construct(string $content)
+            {
+                $this->content = $content;
+            }
+            public function contentType(): string
+            {
+                return 'application/octet-stream';
+            }
+            public function filename(): string
+            {
+                return 'report.xml.gz';
+            }
+            public function contentStream()
+            {
+                return Utils::streamFor($this->content);
+            }
+        };
+
+        $mailAttachment = new MailAttachment($mockAttachment);
+
+        $this->assertSame('application/gzip', $mailAttachment->mimeType());
     }
 }


### PR DESCRIPTION
`classes/Mail/ImapEngine/MailAttachment.php`:49-51
```php
  $this->mime_type = $this->attachment->contentType(); // from email header — attacker-controlled
  if ($this->mime_type === 'application/octet-stream') {
      $this->mime_type = ReportFile::getMimeType(...); // magic bytes fallback
  }
```
The fallback to magic-byte detection only triggers for application/octet-stream. An attacker who sends a gzip file with `Content-Type: text/xml` bypasses decompression entirely - the raw gzip bytes get fed into the XML parser, causing a parse error but also potentially leaking information via error messages, or being exploited if the parser is more lenient than expected.

The `PhpExtension` backend in `classes/Mail/PhpExtension/MailAttachment.php` does it correctly - it always uses ReportFile::getMimeType() (magic bytes first). The ImapEngine backend should match that.

Fix by always using ReportFile::getMimeType() (magic bytes + extension fallback), matching the PhpExtension backend behavior.

Add regression test to ensure the email header is ignored.