### PR TITLE
Add Record Count Limit in XML Parser

### DIFF
--- a/classes/Config.php
+++ b/classes/Config.php
@@ -50,7 +50,7 @@ class Config
         require($config_file);
         foreach ([
                 'debug', 'database', 'mailboxes', 'directories', 'remote_filesystems',
-                'admin', 'users', 'mailer', 'fetcher', 'cleaner', 'custom_css'
+                'admin', 'users', 'mailer', 'fetcher', 'cleaner', 'parser', 'custom_css'
             ] as $key
         ) {
             $this->data[$key] = $$key ?? null;

--- a/classes/Report/Report.php
+++ b/classes/Report/Report.php
@@ -49,7 +49,8 @@ class Report
 
     public static function fromXmlFile($fd)
     {
-        $data = ReportData::fromXmlFile($fd);
+        $records_maximum = Core::instance()->config('parser/records_maximum', 50000);
+        $data = ReportData::fromXmlFile($fd, false, $records_maximum);
         if (!$data->isValid()) {
             throw new SoftException('Incorrect or incomplete report data');
         }

--- a/classes/Report/ReportData.php
+++ b/classes/Report/ReportData.php
@@ -24,6 +24,7 @@ namespace Liuch\DmarcSrg\Report;
 
 use Liuch\DmarcSrg\DateTime;
 use Liuch\DmarcSrg\Exception\RuntimeException;
+use Liuch\DmarcSrg\Exception\SoftException;
 
 class ReportData
 {
@@ -175,7 +176,7 @@ class ReportData
         switch ($this->tag_id) {
             case 'rec':
                 if ($this->records_maximum > 0 && ++$this->record_count > $this->records_maximum) {
-                    throw new RuntimeException('Too many records in the XML report');
+                    throw new SoftException('Too many records in the XML report');
                 }
                 $this->rep_data['records'][] = [];
                 break;

--- a/classes/Report/ReportData.php
+++ b/classes/Report/ReportData.php
@@ -27,14 +27,17 @@ use Liuch\DmarcSrg\Exception\RuntimeException;
 
 class ReportData
 {
-    private $rep_data    = null;
-    private $tag_id      = null;
-    private $skip_depth  = 0;
-    private $strict_mode = false;
+    private $rep_data       = null;
+    private $tag_id         = null;
+    private $skip_depth      = 0;
+    private $strict_mode     = false;
+    private $record_count    = 0;
+    private $records_maximum = 50000;
 
-    private function __construct(bool $strict = false)
+    private function __construct(bool $strict = false, int $records_maximum = 50000)
     {
-        $this->strict_mode = $strict;
+        $this->strict_mode     = $strict;
+        $this->records_maximum = $records_maximum;
     }
 
     public static function fromArray(array $data, bool $strict = false)
@@ -57,9 +60,9 @@ class ReportData
         return $rdata;
     }
 
-    public static function fromXmlFile($fd, $strict = false)
+    public static function fromXmlFile($fd, $strict = false, int $records_maximum = 50000)
     {
-        $rdata = new self($strict);
+        $rdata = new self($strict, $records_maximum);
         $rdata->tag_id = '<root>';
         $rdata->rep_data = [ 'date' => [], 'policy' => [], 'records' => [] ];
 
@@ -171,6 +174,9 @@ class ReportData
 
         switch ($this->tag_id) {
             case 'rec':
+                if ($this->records_maximum > 0 && ++$this->record_count > $this->records_maximum) {
+                    throw new RuntimeException('Too many records in the XML report');
+                }
                 $this->rep_data['records'][] = [];
                 break;
             case 'error_string':

--- a/config/conf.sample.php
+++ b/config/conf.sample.php
@@ -135,6 +135,12 @@ $users = [
     'domain_verification' => 'none'
 ];
 
+$parser = [
+    // Maximum number of <RECORD> elements allowed in a single XML report.
+    // 0 to disable any limiting.
+    'records_maximum' => 50000
+];
+
 //
 $fetcher = [
     'mailboxes' => [

--- a/tests/classes/Report/ReportDataTest.php
+++ b/tests/classes/Report/ReportDataTest.php
@@ -2,7 +2,7 @@
 
 namespace Liuch\DmarcSrg\Report;
 
-use Liuch\DmarcSrg\Exception\RuntimeException;
+use Liuch\DmarcSrg\Exception\SoftException;
 
 class ReportDataTest extends \PHPUnit\Framework\TestCase
 {
@@ -55,7 +55,7 @@ class ReportDataTest extends \PHPUnit\Framework\TestCase
     public function testFromXmlFileWithRecordsAboveLimit(): void
     {
         $fd = $this->generateXml(3);
-        $this->expectException(RuntimeException::class);
+        $this->expectException(SoftException::class);
         $this->expectExceptionMessage('Too many records');
         ReportData::fromXmlFile($fd, false, 2);
         fclose($fd);

--- a/tests/classes/Report/ReportDataTest.php
+++ b/tests/classes/Report/ReportDataTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Liuch\DmarcSrg\Report;
+
+use Liuch\DmarcSrg\Exception\RuntimeException;
+
+class ReportDataTest extends \PHPUnit\Framework\TestCase
+{
+    private function generateXml(int $record_count)
+    {
+        $xml = '<?xml version="1.0" encoding="UTF-8" ?>';
+        $xml .= '<feedback>';
+        $xml .= '<version>1.0</version>';
+        $xml .= '<report_metadata>';
+        $xml .= '<org_name>example.com</org_name>';
+        $xml .= '<email>r@example.com</email>';
+        $xml .= '<report_id>123</report_id>';
+        $xml .= '<date_range><begin>1609459200</begin><end>1609545600</end></date_range>';
+        $xml .= '</report_metadata>';
+        $xml .= '<policy_published>';
+        $xml .= '<domain>example.com</domain>';
+        $xml .= '<p>none</p>';
+        $xml .= '</policy_published>';
+        for ($i = 0; $i < $record_count; ++$i) {
+            $xml .= '<record>';
+            $xml .= '<row><source_ip>192.0.2.1</source_ip><count>1</count></row>';
+            $xml .= '<identifiers><header_from>example.com</header_from></identifiers>';
+            $xml .= '<auth_results><dkim><domain>example.com</domain><result>pass</result></dkim></auth_results>';
+            $xml .= '</record>';
+        }
+        $xml .= '</feedback>';
+
+        $fd = fopen('php://memory', 'r+');
+        fwrite($fd, $xml);
+        rewind($fd);
+        return $fd;
+    }
+
+    public function testFromXmlFileWithRecordsBelowLimit(): void
+    {
+        $fd = $this->generateXml(2);
+        $data = ReportData::fromXmlFile($fd, false, 5);
+        $this->assertCount(2, $data->toArray()['records']);
+        fclose($fd);
+    }
+
+    public function testFromXmlFileWithRecordsAtLimit(): void
+    {
+        $fd = $this->generateXml(3);
+        $data = ReportData::fromXmlFile($fd, false, 3);
+        $this->assertCount(3, $data->toArray()['records']);
+        fclose($fd);
+    }
+
+    public function testFromXmlFileWithRecordsAboveLimit(): void
+    {
+        $fd = $this->generateXml(3);
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Too many records');
+        ReportData::fromXmlFile($fd, false, 2);
+        fclose($fd);
+    }
+
+    public function testFromXmlFileWithLimitZeroIsUnlimited(): void
+    {
+        $fd = $this->generateXml(5);
+        $data = ReportData::fromXmlFile($fd, false, 0);
+        $this->assertCount(5, $data->toArray()['records']);
+        fclose($fd);
+    }
+}

--- a/tests/conf_test_file.php
+++ b/tests/conf_test_file.php
@@ -7,6 +7,9 @@ $directories = null;
 $admin = [];
 $mailer = [];
 $fetcher = [];
+$parser = [
+    'records_maximum' => 50000
+];
 $cleaner = [
     'key_int' => 0,
     'key_bool' => false,


### PR DESCRIPTION
`classes/Report/ReportData.php:173-175`

  Every <RECORD> element appends a new array to $rep_data['records'] with no cap:
```php
  case 'rec':
      $this->rep_data['records'][] = [];  // unbounded
```
A compressed XML with 500,000 empty `<RECORD>` elements fits well within 1 MB compressed. After decompression and parsing, the resulting PHP array will exhaust memory. Combined with issue https://github.com/liuch/dmarc-srg/pull/190, this amplifies the impact.