### PR TITLE
Move fetcher token from query parameter to Authorization header

### DIFF
--- a/classes/Requests/HttpRequest.php
+++ b/classes/Requests/HttpRequest.php
@@ -50,6 +50,20 @@ class HttpRequest extends Request
     }
 
     /**
+     * Returns the Bearer token from the Authorization header or null if not present
+     *
+     * @return ?string
+     */
+    final public function getBearerToken(): ?string
+    {
+        $header = $_SERVER['HTTP_AUTHORIZATION'] ?? $_SERVER['REDIRECT_HTTP_AUTHORIZATION'] ?? '';
+        if (str_starts_with($header, 'Bearer ')) {
+            return substr($header, 7);
+        }
+        return null;
+    }
+
+    /**
      * {@inheritDoc}
      *
      * @throws ValidationException

--- a/config/conf.sample.php
+++ b/config/conf.sample.php
@@ -219,24 +219,38 @@ $fetcher = [
      * This can be useful when for some reason you cannot automate report fetching using cron on the server.
      *
      * Endpoint path: /files.php
-     * Parameters: token=<thistoken>, type=<mailbox|directory|removefs>, ids=<comma-separeted one-based ids, optional>
-     * Example: https://example.net/files.php?token=grGg85bg39&type=mailbox
-     *          Fetchs reports from all cofigurated mailboxes
-     * Example: https://example.net/files.php?token=grGg85bg39&type=directory&ids=1,2
-     *          Fetchs reports from the first and the second server directories
+     * Parameters: type=<mailbox|directory|remotefs>, ids=<comma-separated one-based ids, optional>
+     *
+     * The token is sent via the Authorization header (recommended):
+     *   curl -H "Authorization: Bearer <token>" \
+     *        "https://example.net/files.php?type=mailbox"
+     *     Fetchs reports from all configured mailboxes
+     *   curl -H "Authorization: Bearer <token>" \
+     *        "https://example.net/files.php?type=directory&ids=1,2"
+     *     Fetchs reports from the first and the second server directories
+     *
+     * Alternatively, you can set token_method to 'query' to send the token as a URL parameter
+     * (less secure — the token will appear in access logs and browser history):
+     *   https://example.net/files.php?token=<token>&type=mailbox
      *
      * Note:
      *  - The token must be 20 or more characters length
      *  - All the requests to the endpoint sent more frequently than every 5 minutes will be rejected
      *    This is a protection against configuration errors.
      *
-     *
      * Run the following php code to get random HTTP-safe 256-bit token:
      *   echo rtrim(strtr(base64_encode(random_bytes(32)), '+/', '-_'), '=');
      * The same for Linux shell:
      *   echo $(head -c 32 /dev/urandom | base64 | tr '+/' '-_' | tr -d '=')
      */
-    'access_token' => ''
+    'access_token' => '',
+
+    /**
+     * How the fetcher token is passed to the endpoint.
+     * 'header' (default) — via Authorization: Bearer <token> header. Safer, token stays out of logs.
+     * 'query'              — via ?token=<token> URL parameter. Less secure, kept for backward compatibility.
+     */
+    'token_method' => 'header'
 ];
 
 // Settings for sending summary reports if it is necessary.

--- a/public/files.php
+++ b/public/files.php
@@ -44,8 +44,18 @@ if ($request->getMethod() === 'GET') {
     $auth = $core->auth();
 
     try {
-        if ($request->hasProperty('token')) {
-            $auth->isTokenValid('fetcher', $request->getProperty('token'));
+        $token = null;
+        $token_method = $core->config('fetcher/token_method', 'header');
+        if ($token_method === 'query') {
+            if ($request->hasProperty('token')) {
+                $token = $request->getProperty('token');
+            }
+        } else {
+            $token = $request->getBearerToken();
+        }
+
+        if (!is_null($token)) {
+            $auth->isTokenValid('fetcher', $token);
 
             if (!$request->emptyProperty('type')) {
                 if ($core->checkAccessFrequency('fetcher', 5*60)) {

--- a/tests/classes/Requests/HttpRequestTest.php
+++ b/tests/classes/Requests/HttpRequestTest.php
@@ -94,6 +94,34 @@ class HttpRequestTest extends \PHPUnit\Framework\TestCase
         $this->assertTrue($req->hasJsonData());
     }
 
+    public function testGetBearerToken(): void
+    {
+        $_SERVER = [ 'HTTP_AUTHORIZATION' => 'Bearer abc123' ];
+        $req = new HttpRequest();
+        $this->assertSame('abc123', $req->getBearerToken());
+    }
+
+    public function testGetBearerTokenMissing(): void
+    {
+        $_SERVER = [];
+        $req = new HttpRequest();
+        $this->assertNull($req->getBearerToken());
+    }
+
+    public function testGetBearerTokenMalformed(): void
+    {
+        $_SERVER = [ 'HTTP_AUTHORIZATION' => 'Basic abc123' ];
+        $req = new HttpRequest();
+        $this->assertNull($req->getBearerToken());
+    }
+
+    public function testGetBearerTokenRedirectFallback(): void
+    {
+        $_SERVER = [ 'REDIRECT_HTTP_AUTHORIZATION' => 'Bearer xyz789' ];
+        $req = new HttpRequest();
+        $this->assertSame('xyz789', $req->getBearerToken());
+    }
+
     public function testSetAndGetErrorCode(): void
     {
         $req = new HttpRequest();


### PR DESCRIPTION
The fetcher token is passed as a GET query parameter (`?token=xxx&type=all`) and read directly from `$_GET`. This means the token appears in:

- Web server access logs (`GET /files.php?token=abc123... HTTP/1.1`)
- Browser history
- Referer headers if the page loads any external resources
- Reverse proxy / CDN logs

A leaked token lets anyone trigger report fetching (rate-limited to every 5 minutes by `checkAccessFrequency`, but still).

This PR replaces the insecure `?token=xxx` query parameter with an `Authorization: Bearer <token>` header by default (can be configured for backward compatibility for external crons). 

- Add `HttpRequest::getBearerToken()` to parse the Authorization header
- Add fetcher/token_method config option ('header' | 'query') for backward compatibility during migration
- Update `conf.sample.php` docs with curl header examples
- Add unit tests for `getBearerToken()`