### PR TITLE
Optimize report list and count queries

### DIFF
--- a/classes/Database/Common/CommonReportMapper.php
+++ b/classes/Database/Common/CommonReportMapper.php
@@ -306,10 +306,10 @@ class CommonReportMapper implements ReportMapperInterface
                 . ' SUM(IF(disposition = 0, rcount, 0)) AS rejected,'
                 . ' SUM(IF(disposition = 1, rcount, 0)) AS quarantined'
                 . ' FROM ' . $this->connector->tablePrefix('rptrecords')
-                . ' AS rr RIGHT JOIN (SELECT rp.id, org, begin_time, end_time, external_id,'
+                . ' AS rr INNER JOIN (SELECT rp.id, org, begin_time, end_time, external_id,'
                 . ' fqdn, seen FROM ' . $this->connector->tablePrefix('reports')
                 . ' AS rp INNER JOIN ' . $this->connector->tablePrefix('domains')
-                . ' AS d ON d.id = rp.domain_id' . $user_doms . $cond_str0 . $order_str
+                . ' AS d ON d.id = rp.domain_id' . $user_doms . $cond_str0
                 . ') AS rp ON rp.id = rr.report_id GROUP BY rp.id'
                 . $cond_str1 . $order_str . $limit_str
             );
@@ -376,7 +376,7 @@ class CommonReportMapper implements ReportMapperInterface
                     . ' SUM(IF(disposition = 0, rcount, 0)) AS rejected,'
                     . ' SUM(IF(disposition = 1, rcount, 0)) AS quarantined'
                     . ' FROM ' . $this->connector->tablePrefix('rptrecords')
-                    . ' AS rr RIGHT JOIN (SELECT rp.id FROM ' . $this->connector->tablePrefix('reports')
+                    . ' AS rr INNER JOIN (SELECT rp.id FROM ' . $this->connector->tablePrefix('reports')
                     . ' AS rp INNER JOIN ' . $this->connector->tablePrefix('domains')
                     . ' AS d ON d.id = rp.domain_id' . $this->sqlUserRestriction($user_id, 'd.id')
                     . $this->sqlConditionList($f_data, ' AND ', 0)
@@ -418,6 +418,66 @@ class CommonReportMapper implements ReportMapperInterface
             throw new DatabaseFatalException('Failed to get the number of reports', -1, $e);
         }
         return $cnt;
+    }
+
+    /**
+     * Returns total and unread counts matching the specified filter
+     *
+     * @param array $filter  Key-value array with filtering parameters
+     * @param int   $user_id User ID to count reports for
+     *
+     * @return array Key-value array with `total` and `unread` keys
+     */
+    public function counts(array &$filter, int $user_id): array
+    {
+        $res = [ 'total' => 0, 'unread' => 0 ];
+        $f_data = $this->prepareFilterData($filter, 'rp');
+        try {
+            if (isset($filter['dkim']) || isset($filter['spf']) || isset($filter['disposition'])) {
+                $st = $this->connector->dbh()->prepare(
+                    'SELECT COUNT(*) AS total, SUM(IF(seen = 0, 1, 0)) AS unread FROM ('
+                    . 'SELECT seen,'
+                    . ' SUM(IF(dkim_align = 0, rcount, 0)) AS dkim_align_fail,'
+                    . ' SUM(IF(dkim_align = 1, rcount, 0)) AS dkim_align_unknown,'
+                    . ' SUM(IF(spf_align = 0, rcount, 0)) AS spf_align_fail,'
+                    . ' SUM(IF(spf_align = 1, rcount, 0)) AS spf_align_unknown,'
+                    . ' SUM(IF(disposition = 0, rcount, 0)) AS rejected,'
+                    . ' SUM(IF(disposition = 1, rcount, 0)) AS quarantined'
+                    . ' FROM ' . $this->connector->tablePrefix('rptrecords')
+                    . ' AS rr INNER JOIN (SELECT rp.id, seen FROM ' . $this->connector->tablePrefix('reports')
+                    . ' AS rp INNER JOIN ' . $this->connector->tablePrefix('domains')
+                    . ' AS d ON d.id = rp.domain_id' . $this->sqlUserRestriction($user_id, 'd.id')
+                    . $this->sqlConditionList($f_data, ' AND ', 0)
+                    . ') AS rp ON rp.id = rr.report_id GROUP BY rp.id'
+                    . $this->sqlConditionList($f_data, ' HAVING ', 1)
+                    . ') AS ct'
+                );
+            } elseif ($user_id) {
+                $st = $this->connector->dbh()->prepare(
+                    'SELECT COUNT(*) AS total, SUM(IF(seen = 0, 1, 0)) AS unread'
+                    . ' FROM ' . $this->connector->tablePrefix('reports') . ' AS rp'
+                    . ' INNER JOIN ' . $this->connector->tablePrefix('domains')
+                    . ' AS d ON d.id = rp.domain_id' . $this->sqlUserRestriction($user_id, 'd.id')
+                    . $this->sqlConditionList($f_data, ' AND ', 0)
+                );
+            } else {
+                $st = $this->connector->dbh()->prepare(
+                    'SELECT COUNT(*) AS total, SUM(IF(seen = 0, 1, 0)) AS unread'
+                    . ' FROM ' . $this->connector->tablePrefix('reports') . ' AS rp'
+                    . $this->sqlConditionList($f_data, ' WHERE ', 0)
+                );
+            }
+            $l_empty = [ 'offset' => 0, 'count' => 0 ];
+            $this->sqlBindValues($st, $f_data, $l_empty);
+            $st->execute();
+            $row = $st->fetch(\PDO::FETCH_NUM);
+            $res['total'] = intval($row[0]);
+            $res['unread'] = intval($row[1]);
+            $st->closeCursor();
+        } catch (\PDOException $e) {
+            throw new DatabaseFatalException('Failed to get the number of reports', -1, $e);
+        }
+        return $res;
     }
 
     /**

--- a/classes/Database/DatabaseController.php
+++ b/classes/Database/DatabaseController.php
@@ -39,7 +39,7 @@ use Liuch\DmarcSrg\Exception\DatabaseFatalException;
  */
 class DatabaseController
 {
-    public const REQUIRED_VERSION = '4.0';
+    public const REQUIRED_VERSION = '4.1';
 
     private $conf_data = null;
     /** @var DatabaseConnector|null */

--- a/classes/Database/Mariadb/Connector.php
+++ b/classes/Database/Mariadb/Connector.php
@@ -569,7 +569,9 @@ class Connector extends DatabaseConnector
                     'definition' => 'varchar(255) NULL'
                 ]
             ],
-            'additional' => 'PRIMARY KEY (id), KEY (report_id), KEY (ip)',
+            'additional' => 'PRIMARY KEY (id), KEY (report_id), KEY (ip),'
+                            . ' KEY covering_agg (report_id, dkim_align, spf_align, disposition, rcount),'
+                            . ' KEY ip_report (ip, report_id, rcount)',
             'table_options' => 'ENGINE=InnoDB DEFAULT CHARSET=utf8'
         ],
         'reportlog' => [

--- a/classes/Database/Mariadb/UpgraderMapper.php
+++ b/classes/Database/Mariadb/UpgraderMapper.php
@@ -342,6 +342,40 @@ class UpgraderMapper implements UpgraderMapperInterface
     }
 
     /**
+     * Upgrades the database structure from v4.0 to v4.1
+     *
+     * @return string New version of the database structure
+     */
+    private function up40(): string
+    {
+        $db = $this->connector->dbh();
+        try {
+            $this->connector->setANSIMode(false);
+            $rr_tn = $this->connector->tablePrefix('rptrecords');
+            if (!$this->indexExists($db, $rr_tn, 'covering_agg')) {
+                $db->query(
+                    'ALTER TABLE ' . $rr_tn
+                    . ' ADD KEY covering_agg (report_id, dkim_align, spf_align, disposition, rcount)'
+                );
+            }
+            if (!$this->indexExists($db, $rr_tn, 'ip_report')) {
+                $db->query(
+                    'ALTER TABLE ' . $rr_tn . ' ADD KEY ip_report (ip, report_id, rcount)'
+                );
+            }
+            $sys_tn = $this->connector->tablePrefix('system');
+            $db->query(
+                'UPDATE `' . $sys_tn . '` SET value = "4.1" WHERE user_id = 0 AND `key` = "version"'
+            );
+        } catch (\PDOException $e) {
+            throw $this->dbFatalException($e);
+        } finally {
+            $this->connector->setANSIMode(true);
+        }
+        return '4.1';
+    }
+
+    /**
      * Checks if the specified column exists in the specified table of the database
      *
      * @param object $db     Connection handle of the database
@@ -406,6 +440,7 @@ class UpgraderMapper implements UpgraderMapperInterface
         'ver_2.0'  => 'up20',
         'ver_3.0'  => 'up30',
         'ver_3.1'  => 'up31',
-        'ver_3.2'  => 'up32'
+        'ver_3.2'  => 'up32',
+        'ver_4.0'  => 'up40'
     ];
 }

--- a/classes/Database/ReportMapperInterface.php
+++ b/classes/Database/ReportMapperInterface.php
@@ -99,6 +99,16 @@ interface ReportMapperInterface
     public function count(array &$filter, array &$limit, int $user_id): int;
 
     /**
+     * Returns total and unread counts matching the specified filter
+     *
+     * @param array $filter  Key-value array with filtering parameters
+     * @param int   $user_id User ID to count reports for
+     *
+     * @return array Key-value array with `total` and `unread` keys
+     */
+    public function counts(array &$filter, int $user_id): array;
+
+    /**
      * Deletes reports from the database
      *
      * It deletes repors form the database. The filter options `dkim` and `spf` do not affect this.

--- a/classes/Report/ReportList.php
+++ b/classes/Report/ReportList.php
@@ -178,6 +178,16 @@ class ReportList
     }
 
     /**
+     * Returns total and unread counts matching the current filter
+     *
+     * @return array Key-value array with `total` and `unread` keys
+     */
+    public function counts(): array
+    {
+        return $this->db->getMapper('report')->counts($this->filter, $this->user->id());
+    }
+
+    /**
      * Deletes reports from the database
      *
      * It deletes repors form the database. The filter items `dkim`, `spf` and `disposition` do not affect this.

--- a/public/list.php
+++ b/public/list.php
@@ -64,27 +64,15 @@ if (Core::requestMethod() == 'GET') {
                         }
                         ++$tc;
                     }
+                    $res['count'] = [ 'total' => $tc, 'unread' => $uc ];
                 } else {
                     $list = new ReportList($core->getCurrentUser());
                     $filter = Common::getFilter();
                     if ($filter) {
                         $list->setFilter($filter);
                     }
-                    $tc = $list->count();
-                    if (!$filter) {
-                        $filter = [];
-                    }
-                    $status = $filter['status'] ?? '';
-                    if ($status === 'unread') {
-                        $uc = $tc;
-                    } elseif ($status === 'read') {
-                        $uc = 0;
-                    } else {
-                        $filter['status'] = 'unread';
-                        $uc = $list->setFilter($filter)->count();
-                    }
+                    $res['count'] = $list->counts();
                 }
-                $res['count'] = [ 'total' => $tc, 'unread' => $uc ];
             }
             if (array_search('filters', $lst) !== false) {
                 $res['filters'] = (new ReportList($core->getCurrentUser()))->getFilterList();


### PR DESCRIPTION
This PR implements four targeted performance optimizations for the report list page, plus two composite indexes on `rptrecords`.

### Query optimizations

1. Combine total + unread counts into a single query
Adds a new `counts()` method to `ReportMapperInterface` that returns both `total` and `unread` in one pass. The frontend no longer runs two separate aggregation queries (or a second filtered query for unread). The existing `count()` method is preserved for backward compatibility.

2. Replace `RIGHT JOIN` with `INNER JOIN`
In the aggregate-filter branches of `list()` and `count()`, `rr RIGHT JOIN rp` has been changed to `rr INNER JOIN rp`. Reports with zero `rptrecords` produce all `NULL` aggregates, which fail every `> 0` `HAVING` condition, so the `RIGHT JOIN` was only adding rows that would be discarded anyway.

3. Remove redundant `ORDER BY` in the derived table
The subquery that selects from `reports` no longer includes `$order_str`. Sorting inside a derived table is wasteful - the outer `GROUP BY` + final `ORDER BY` already control the result order.

4. Add covering indexes on `rptrecords`
- `covering_agg (report_id, dkim_align, spf_align, disposition, rcount)` - eliminates heap lookups for the aggregation queries in `list()`, `count()`, and statistics mappers.  
- `ip_report (ip, report_id, rcount)` - accelerates host/IP lookups in `CommonHostMapper`.

### Database migration

- Bumps `REQUIRED_VERSION` to `4.1`.
- Adds `up40()` in `UpgraderMapper` to conditionally create both indexes (guarded by `indexExists()` for re-run safety).