### PR TITLE
Add Docker container setup with PHP 8.4-FPM, and nginx

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,35 +1,20 @@
-# Git
-.git
-.gitattributes
-.gitignore
+# Ignore everything at root level
+/*
 
-# GitHub
-.github
+# Application code
+!/classes/
+!/config/
+!/public/
+!/utils/
+!/template.html
+!/composer.json
+!/composer.lock
 
-# Docker
-Dockerfile
-docker-compose.yml
+# Docker build files
+!/docker/
+!/Dockerfile
+!/docker-compose.yml
+!/.dockerignore
 
-# Documentation and tests
-docs
-tests
-screenshots
-*.md
-
-# Editor / IDE
-.editorconfig
-.vscode
-.idea
-
-# PHP
-vendor
-.phpunit.result.cache
-phpunit.xml
-composer.phar
-
-# Misc
-*.log
-*.swp
-*.swo
-*~
-.env
+# Re-ignore local sensitive config
+config/conf.php

--- a/.dockerignore
+++ b/.dockerignore
@@ -6,6 +6,7 @@
 !/config/
 !/public/
 !/utils/
+!/init.php
 !/template.html
 !/composer.json
 !/composer.lock

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,35 @@
+# Git
+.git
+.gitattributes
+.gitignore
+
+# GitHub
+.github
+
+# Docker
+Dockerfile
+docker-compose.yml
+
+# Documentation and tests
+docs
+tests
+screenshots
+*.md
+
+# Editor / IDE
+.editorconfig
+.vscode
+.idea
+
+# PHP
+vendor
+.phpunit.result.cache
+phpunit.xml
+composer.phar
+
+# Misc
+*.log
+*.swp
+*.swo
+*~
+.env

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,59 @@
+name: Docker Build and Publish
+
+on:
+  push:
+    tags:
+      - 'v*'
+  release:
+    types: [published]
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version tag for the image (e.g., v2.5.1, dev-20240526)'
+        description: 'Version tag for the image (e.g., 2.5.1, dev-20240526)'
         required: false
         default: ''
       latest:
@@ -58,7 +58,6 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
-            type=ref,event=tag
             type=raw,value=${{ inputs.version }},enable=${{ inputs.version != '' }}
             type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/') || inputs.latest }}
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,6 +7,16 @@ on:
   release:
     types: [published]
   workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version tag for the image (e.g., v2.5.1, dev-20240526)'
+        required: false
+        default: ''
+      latest:
+        description: 'Tag as latest'
+        type: boolean
+        required: false
+        default: false
 
 permissions:
   contents: read
@@ -49,7 +59,8 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
             type=ref,event=tag
-            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/') }}
+            type=raw,value=${{ inputs.version }},enable=${{ inputs.version != '' }}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/') || inputs.latest }}
 
       - name: Build and push
         uses: docker/build-push-action@v6

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -46,7 +46,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
             type=ref,event=tag
-            type=raw,value=latest,enable=${{ github.event_name == 'release' }}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/') }}
 
       - name: Build and push
         uses: docker/build-push-action@v6

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -8,6 +8,9 @@ on:
     types: [published]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -49,6 +49,21 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Extract version parts
+        id: version
+        run: |
+          if [ -n "${{ inputs.version }}" ]; then
+            VERSION="${{ inputs.version }}"
+          else
+            VERSION="${GITHUB_REF#refs/tags/}"
+            VERSION="${VERSION#v}"
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          MINOR=$(echo "$VERSION" | cut -d. -f1,2)
+          MAJOR=$(echo "$VERSION" | cut -d. -f1)
+          echo "minor=$MINOR" >> "$GITHUB_OUTPUT"
+          echo "major=$MAJOR" >> "$GITHUB_OUTPUT"
+
       - name: Extract metadata
         id: meta
         uses: docker/metadata-action@v5
@@ -58,7 +73,9 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
-            type=raw,value=${{ inputs.version }},enable=${{ inputs.version != '' }}
+            type=raw,value=${{ steps.version.outputs.version }},enable=${{ steps.version.outputs.version != '' }}
+            type=raw,value=${{ steps.version.outputs.minor }},enable=${{ steps.version.outputs.version != '' }}
+            type=raw,value=${{ steps.version.outputs.major }},enable=${{ steps.version.outputs.version != '' }}
             type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/') || inputs.latest }}
 
       - name: Build and push

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -45,7 +45,8 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=ref,event=tag
+            type=raw,value=latest,enable=${{ github.event_name == 'release' }}
 
       - name: Build and push
         uses: docker/build-push-action@v6

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,6 +56,9 @@ RUN mkdir -p /run/php /run/nginx /var/lib/nginx/tmp /var/cache/nginx /var/log/ng
 
 EXPOSE 8080
 
+HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
+  CMD curl -fsS http://127.0.0.1:8080/healthz.php >/dev/null || exit 1
+
 USER www-data
 
 ENTRYPOINT ["/sbin/tini", "--"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,58 @@
+FROM php:8.4-fpm-alpine
+
+# Install system dependencies and PHP extensions
+RUN apk add --no-cache \
+    nginx \
+    tini \
+    curl \
+    libzip \
+    libxml2 \
+    icu \
+    oniguruma \
+    && apk add --no-cache --virtual .build-deps \
+    $PHPIZE_DEPS \
+    libzip-dev \
+    libxml2-dev \
+    icu-dev \
+    oniguruma-dev \
+    && docker-php-ext-install -j$(nproc) \
+    pdo_mysql \
+    mysqli \
+    mbstring \
+    xml \
+    zip \
+    opcache \
+    && apk del .build-deps \
+    && rm -rf /var/cache/apk/* /tmp/pear
+
+# Install Composer
+COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
+
+# Copy runtime configurations
+COPY docker/php.ini /usr/local/etc/php/conf.d/99-dmarc-srg.ini
+COPY docker/php-fpm.conf /usr/local/etc/php-fpm.d/www.conf
+COPY docker/nginx.conf /etc/nginx/nginx.conf
+COPY docker/entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+# Set working directory and copy application
+WORKDIR /var/www/dmarc-srg
+COPY --chown=www-data:www-data . .
+
+# Install PHP dependencies
+RUN composer install --no-dev --prefer-dist --no-interaction --optimize-autoloader \
+    && rm -rf /root/.composer/cache
+
+# Ensure correct permissions
+RUN chown -R www-data:www-data /var/www/dmarc-srg \
+    && chmod -R u=rwX,g=rX,o=rX /var/www/dmarc-srg
+
+# Ensure runtime directories are writable by www-data
+# Alpine's nginx package defaults to the 'nginx' user, but we run as www-data.
+RUN mkdir -p /run/php /run/nginx /var/lib/nginx/tmp /var/cache/nginx /var/log/nginx \
+    && chown -R www-data:www-data /run/php /run/nginx /var/lib/nginx /var/cache/nginx /var/log/nginx
+
+EXPOSE 8080
+
+ENTRYPOINT ["/sbin/tini", "--"]
+CMD ["/usr/local/bin/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,8 +28,7 @@ RUN apk add --no-cache \
 # Install Composer
 COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
 
-# Copy runtime configurations
-COPY docker/php.ini /usr/local/etc/php/conf.d/99-dmarc-srg.ini
+# Copy runtime configurations (except php.ini — applied after build to avoid open_basedir issues)
 COPY docker/php-fpm.conf /usr/local/etc/php-fpm.d/www.conf
 COPY docker/nginx.conf /etc/nginx/nginx.conf
 COPY docker/entrypoint.sh /usr/local/bin/entrypoint.sh
@@ -43,6 +42,9 @@ COPY --chown=www-data:www-data . .
 RUN composer install --no-dev --prefer-dist --no-interaction --optimize-autoloader \
     && rm -rf /root/.composer/cache
 
+# Apply production PHP settings only after build steps are complete
+COPY docker/php.ini /usr/local/etc/php/conf.d/99-dmarc-srg.ini
+
 # Ensure correct permissions
 RUN chown -R www-data:www-data /var/www/dmarc-srg \
     && chmod -R u=rwX,g=rX,o=rX /var/www/dmarc-srg
@@ -53,6 +55,8 @@ RUN mkdir -p /run/php /run/nginx /var/lib/nginx/tmp /var/cache/nginx /var/log/ng
     && chown -R www-data:www-data /run/php /run/nginx /var/lib/nginx /var/cache/nginx /var/log/nginx
 
 EXPOSE 8080
+
+USER www-data
 
 ENTRYPOINT ["/sbin/tini", "--"]
 CMD ["/usr/local/bin/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,9 @@
 FROM php:8.4-fpm-alpine
 
+ARG VERSION="dev"
+ARG BUILD_DATE
+ARG VCS_REF
+
 # Install system dependencies and PHP extensions
 RUN apk add --no-cache \
     nginx \
@@ -39,7 +43,7 @@ WORKDIR /var/www/dmarc-srg
 COPY --chown=www-data:www-data . .
 
 # Install PHP dependencies
-RUN composer install --no-dev --prefer-dist --no-interaction --optimize-autoloader \
+RUN composer install --no-dev --prefer-dist --no-interaction --optimize-autoloader --no-cache \
     && rm -rf /root/.composer/cache
 
 # Apply production PHP settings only after build steps are complete
@@ -53,6 +57,15 @@ RUN chown -R www-data:www-data /var/www/dmarc-srg \
 # Alpine's nginx package defaults to the 'nginx' user, but we run as www-data.
 RUN mkdir -p /run/php /run/nginx /var/lib/nginx/tmp /var/cache/nginx /var/log/nginx \
     && chown -R www-data:www-data /run/php /run/nginx /var/lib/nginx /var/cache/nginx /var/log/nginx
+
+LABEL org.opencontainers.image.title="dmarc-srg" \
+      org.opencontainers.image.description="A php parser, viewer and summary report generator for incoming DMARC reports." \
+      org.opencontainers.image.source="https://github.com/liuch/dmarc-srg" \
+      org.opencontainers.image.url="https://github.com/liuch/dmarc-srg#readme" \
+      org.opencontainers.image.licenses="GPL-3.0" \
+      org.opencontainers.image.version=${VERSION} \
+      org.opencontainers.image.created=${BUILD_DATE} \
+      org.opencontainers.image.revision=${VCS_REF}
 
 EXPOSE 8080
 

--- a/README.md
+++ b/README.md
@@ -158,3 +158,115 @@ Each directory specified in the configuration file is scanned for presence of fi
 
 ## Uploaded report files from the web interface
 Uploading report files via the web interface is pretty standard. The upload result can be seen in a popup message and in the internal log. The number of simultaneously uploaded files and their size are limited only by the settings of your server (See `upload_max_filesize` and `post_max_size` in your `php.ini` file).
+
+# Docker
+
+A production-ready Docker image is available. It runs PHP 8.4-FPM and nginx in a single container, using a Unix socket for FastCGI.
+
+## Quick Start with Docker Compose
+
+1. Copy the sample configuration and edit it:
+
+```sh
+cp config/conf.sample.php config/conf.php
+```
+
+2. Edit `config/conf.php` and set at least the database credentials and admin password.
+
+3. Start the stack:
+
+```sh
+docker compose up -d
+```
+
+4. Initialize the database:
+
+```sh
+docker compose exec app php -f utils/database_admin.php init
+```
+
+5. Open http://localhost:8080 in your browser.
+
+## Using the pre-built image
+
+Images are published to GitHub Container Registry on every release:
+
+```sh
+docker pull ghcr.io/smeinecke/dmarc-srg:latest
+```
+
+To use it in `docker-compose.yml`, replace the `build` section with:
+
+```yaml
+  app:
+    image: ghcr.io/smeinecke/dmarc-srg:latest
+```
+
+## Building the image locally
+
+```sh
+docker build -t dmarc-srg .
+```
+
+## Configuration
+
+Mount your `config/conf.php` into the container as a read-only file:
+
+```yaml
+volumes:
+  - ./config/conf.php:/var/www/dmarc-srg/config/conf.php:ro
+```
+
+Database and other settings should be configured in this file. The default `docker-compose.yml` includes a MariaDB service with the credentials:
+
+- Host: `db`
+- Database: `dmarc`
+- User: `dmarc_user`
+- Password: `changeme` (change via `DB_PASSWORD` environment variable)
+
+## Running utility scripts
+
+Console utilities in `utils/` can be run inside the container:
+
+```sh
+# Fetch reports from mailboxes
+docker compose exec app php -f utils/fetch_reports.php
+
+# Generate a summary report
+docker compose exec app php -f utils/summary_report.php domain=all period=lastweek
+
+# Check configuration
+docker compose exec app php -f utils/check_config.php
+```
+
+## Periodic jobs
+
+You can run periodic jobs using host cron with `docker compose exec`. For example, add the following to your host's crontab:
+
+```cron
+# Fetch reports every hour
+0 * * * * cd /path/to/dmarc-srg && docker compose exec -T app php -f utils/fetch_reports.php
+
+# Weekly summary report
+0 9 * * 1 cd /path/to/dmarc-srg && docker compose exec -T app php -f utils/summary_report.php domain=all period=lastweek
+```
+
+## Backups
+
+The MariaDB data is stored in a Docker named volume (`db_data`). To back up the database:
+
+```sh
+docker compose exec db mariadb-dump -u root -p dmarc > dmarc-backup.sql
+```
+
+To restore:
+
+```sh
+cat dmarc-backup.sql | docker compose exec -T db mariadb -u root -p dmarc
+```
+
+## Architecture
+
+- **Application container:** PHP 8.4-FPM + nginx on Alpine Linux. FastCGI communicates via a Unix socket at `/run/php/php-fpm.sock`. Only port 8080 is exposed.
+- **Database container:** MariaDB with a persistent Docker volume.
+- Non-public directories (`config/`, `classes/`, `utils/`, `vendor/`) are blocked at the nginx level.

--- a/README.md
+++ b/README.md
@@ -269,4 +269,4 @@ cat dmarc-backup.sql | docker compose exec -T db mariadb -u root -p dmarc
 
 - **Application container:** PHP 8.4-FPM + nginx on Alpine Linux. FastCGI communicates via a Unix socket at `/run/php/php-fpm.sock`. Only port 8080 is exposed.
 - **Database container:** MariaDB with a persistent Docker volume.
-- Non-public directories (`config/`, `classes/`, `utils/`, `vendor/`) are blocked at the nginx level.
+- The web root is restricted to `public/`; non-public directories (`config/`, `classes/`, `utils/`, `vendor/`) are outside the web root and unreachable.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,38 @@
+services:
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "8080:8080"
+    volumes:
+      - ./config/conf.php:/var/www/dmarc-srg/config/conf.php:ro
+    depends_on:
+      db:
+        condition: service_healthy
+    restart: unless-stopped
+    environment:
+      DB_HOST: db
+      DB_NAME: dmarc
+      DB_USER: dmarc_user
+      DB_PASSWORD: ${DB_PASSWORD:-changeme}
+
+  db:
+    image: mariadb:11
+    environment:
+      MARIADB_ROOT_PASSWORD: ${DB_ROOT_PASSWORD:-changeme}
+      MARIADB_DATABASE: dmarc
+      MARIADB_USER: dmarc_user
+      MARIADB_PASSWORD: ${DB_PASSWORD:-changeme}
+    volumes:
+      - db_data:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "mariadb-admin", "ping", "-h", "localhost", "-u", "root", "-p${DB_ROOT_PASSWORD:-changeme}"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
+    restart: unless-stopped
+
+volumes:
+  db_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,11 +7,14 @@ services:
       - "8080:8080"
     volumes:
       - ./config/conf.php:/var/www/dmarc-srg/config/conf.php:ro
+      # To add custom CA certificates, mount them and set SSL_CERT_FILE:
+      # - ./my-ca.pem:/certs/my-ca.pem:ro
     depends_on:
       db:
         condition: service_healthy
     restart: unless-stopped
     environment:
+      # SSL_CERT_FILE: /certs/my-ca.pem
       DB_HOST: db
       DB_NAME: dmarc
       DB_USER: dmarc_user

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -9,9 +9,21 @@ php_fpm_pid="$!"
 nginx -g 'daemon off;' &
 nginx_pid="$!"
 
-trap 'kill "$php_fpm_pid" "$nginx_pid" 2>/dev/null || true' TERM INT
+cron_pid=""
+if [ "${ENABLE_FETCH_CRON:-true}" = "true" ]; then
+    interval="${FETCH_INTERVAL_SECONDS:-3600}"
+    (
+        while true; do
+            sleep "$interval"
+            php -f /var/www/dmarc-srg/utils/fetch_reports.php || true
+        done
+    ) &
+    cron_pid="$!"
+fi
 
-wait -n "$php_fpm_pid" "$nginx_pid"
+trap 'kill "$php_fpm_pid" "$nginx_pid" ${cron_pid:+"$cron_pid"} 2>/dev/null || true' TERM INT
 
-kill "$php_fpm_pid" "$nginx_pid" 2>/dev/null || true
+wait -n "$php_fpm_pid" "$nginx_pid" ${cron_pid:+"$cron_pid"}
+
+kill "$php_fpm_pid" "$nginx_pid" ${cron_pid:+"$cron_pid"} 2>/dev/null || true
 wait

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+set -eu
+
+rm -f /run/php/php-fpm.sock
+
+php-fpm &
+php_fpm_pid="$!"
+
+nginx -g 'daemon off;' &
+nginx_pid="$!"
+
+trap 'kill "$php_fpm_pid" "$nginx_pid" 2>/dev/null || true' TERM INT
+
+wait -n "$php_fpm_pid" "$nginx_pid"
+
+kill "$php_fpm_pid" "$nginx_pid" 2>/dev/null || true
+wait

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -28,6 +28,9 @@ http {
     add_header X-Frame-Options "SAMEORIGIN" always;
     add_header X-Content-Type-Options "nosniff" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    add_header Content-Security-Policy "default-src 'none'; style-src 'self'; img-src 'self'; script-src 'self'; connect-src 'self'; media-src 'self'; form-action 'self'; base-uri 'none'; frame-ancestors 'none'" always;
+    add_header Permissions-Policy "interest-cohort=()" always;
+    add_header Strict-Transport-Security "max-age=31536000" always;
 
     server {
         listen 8080;

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -42,12 +42,6 @@ http {
             return 404;
         }
 
-        # Block access to sensitive directories
-        location ~ ^/(config|classes|utils|vendor)/ {
-            deny all;
-            return 404;
-        }
-
         # Block access to common config/sensitive files
         location ~ \.(ini|log|sh|sql|git|lock)$ {
             deny all;

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -1,0 +1,81 @@
+user www-data;
+worker_processes auto;
+error_log /dev/stderr warn;
+pid /tmp/nginx.pid;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    include /etc/nginx/mime.types;
+    default_type application/octet-stream;
+
+    log_format main '$remote_addr - $remote_user [$time_local] "$request" '
+                    '$status $body_bytes_sent "$http_referer" '
+                    '"$http_user_agent"';
+
+    access_log /dev/stdout main;
+
+    sendfile on;
+    tcp_nopush on;
+    tcp_nodelay on;
+    keepalive_timeout 65;
+    types_hash_max_size 2048;
+    server_tokens off;
+
+    # Security headers
+    add_header X-Frame-Options "SAMEORIGIN" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+
+    server {
+        listen 8080;
+        root /var/www/dmarc-srg/public;
+        index index.php;
+
+        location ^~ /.well-known/ {
+            try_files $uri =404;
+        }
+
+        location ~ /\.(?!well-known) {
+            return 404;
+        }
+
+        # Block access to sensitive directories
+        location ~ ^/(config|classes|utils|vendor)/ {
+            deny all;
+            return 404;
+        }
+
+        # Block access to common config/sensitive files
+        location ~ \.(ini|log|sh|sql|git|lock)$ {
+            deny all;
+            return 404;
+        }
+
+        location ~* \.(?:jpg|jpeg|png|gif|ico|css|js|svg|woff|woff2|ttf|eot)$ {
+            try_files $uri =404;
+            expires 1M;
+            add_header Cache-Control "public, immutable";
+        }
+
+        # Main location
+        location / {
+            try_files $uri $uri/ /index.php?$query_string;
+        }
+
+        location ~ \.php$ {
+            try_files $uri =404;
+
+            include fastcgi_params;
+            fastcgi_pass unix:/run/php/php-fpm.sock;
+            fastcgi_index index.php;
+
+            fastcgi_param SCRIPT_FILENAME $realpath_root$fastcgi_script_name;
+            fastcgi_param DOCUMENT_ROOT $realpath_root;
+
+            fastcgi_read_timeout 300s;
+        }
+    }
+}

--- a/docker/php-fpm.conf
+++ b/docker/php-fpm.conf
@@ -1,0 +1,27 @@
+[global]
+error_log = /proc/self/fd/2
+daemonize = no
+
+[www]
+listen = /run/php/php-fpm.sock
+listen.owner = www-data
+listen.group = www-data
+listen.mode = 0660
+
+user = www-data
+group = www-data
+
+pm = dynamic
+pm.max_children = 8
+pm.start_servers = 2
+pm.min_spare_servers = 1
+pm.max_spare_servers = 3
+pm.max_requests = 500
+
+; Logging
+access.log = /proc/self/fd/2
+catch_workers_output = yes
+decorate_workers_output = no
+
+; Keep env vars for Docker / Compose
+clear_env = no

--- a/docker/php.ini
+++ b/docker/php.ini
@@ -7,6 +7,7 @@ upload_max_filesize = 20M
 max_execution_time = 300
 max_input_vars = 10000
 date.timezone = UTC
+open_basedir = "/var/www/dmarc-srg/:/tmp/:/var/lib/nginx/tmp/"
 
 [opcache]
 opcache.enable = 1

--- a/docker/php.ini
+++ b/docker/php.ini
@@ -1,0 +1,21 @@
+[PHP]
+engine = On
+expose_php = Off
+memory_limit = 256M
+post_max_size = 20M
+upload_max_filesize = 20M
+max_execution_time = 300
+max_input_vars = 10000
+date.timezone = UTC
+
+[opcache]
+opcache.enable = 1
+opcache.memory_consumption = 128
+opcache.interned_strings_buffer = 8
+opcache.max_accelerated_files = 4000
+opcache.revalidate_freq = 2
+opcache.fast_shutdown = 1
+
+[Session]
+session.cookie_httponly = 1
+session.use_strict_mode = 1

--- a/public/healthz.php
+++ b/public/healthz.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Liuch\DmarcSrg;
+
+ob_start();
+
+try {
+    require realpath(__DIR__ . '/..') . '/init.php';
+
+    if (Core::instance() === null) {
+        throw new \RuntimeException('Core instance is null');
+    }
+
+    ob_end_clean();
+    header('Content-Type: text/plain; charset=utf-8');
+    http_response_code(200);
+    echo "ok\n";
+} catch (\Throwable $e) {
+    ob_end_clean();
+    error_log('healthz failed: ' . $e->getMessage());
+    header('Content-Type: text/plain; charset=utf-8');
+    http_response_code(503);
+    echo "fail\n";
+}


### PR DESCRIPTION
- Dockerfile based on php:8.4-fpm-alpine with nginx + tini
- Unix socket FastCGI between nginx and PHP-FPM
- nginx listens on port 8080, blocks access to config/, classes/, utils/, vendor/, and dotfiles
- docker-compose.yml with MariaDB service
- .github/workflows/docker.yml to build and push multi-platform images to ghcr.io on tags, releases, and manual dispatch
- Docker usage section added to README.md