### PR TITLE
Add opt-in set_envelope_from to set the SMTP envelope sender

### DIFF
--- a/classes/Mail/MailerInternal.php
+++ b/classes/Mail/MailerInternal.php
@@ -60,11 +60,15 @@ class MailerInternal extends Mailer
         $ex = null;
         $res = null;
         try {
+            $extra = !empty($this->params['set_envelope_from'])
+                ? '-f' . escapeshellarg($this->from)
+                : '';
             $res = mail(
                 implode(',', $this->addr),
                 mb_encode_mimeheader($this->subj, 'UTF-8'),
                 implode("\r\n", $this->body->content()),
-                $headers
+                $headers,
+                $extra
             );
         } catch (\Exception $e) {
             $ex = $e;

--- a/config/conf.sample.php
+++ b/config/conf.sample.php
@@ -273,6 +273,15 @@ $mailer = [
      */
     'default' => 'user@yourdomain.net',
 
+    /**
+     * Set the SMTP envelope sender (Return-Path) to the 'from' address by passing
+     * the '-f' option to sendmail. This makes outgoing mail pass SPF and DKIM
+     * alignment for DMARC. Only applies to library='internal', method='mail'.
+     * Note: on MTAs where the web/cron user is not a trusted sendmail user, enabling
+     * this may add an 'X-Warning' header. Default: false (unchanged behavior).
+     */
+    'set_envelope_from' => false,
+
     /*
      * For method 'smtp' the following parameters must be specified:
      */


### PR DESCRIPTION
## Problem

I run dmarc-srg on my own mail server, and its own aggregate reports showed me that the summary mail it sends was failing DMARC alignment. Gmail reported the sending IP as `spf=pass` but with no aligned DKIM signature, so the mail passed DMARC on SPF alone.

The cause is in `classes/Mail/MailerInternal.php`: `send()` calls PHP's `mail()` with four arguments and never passes the 5th `additional_params`, so the envelope sender is never set. The envelope then defaults to the account the PHP process runs as (for a cron job, typically `<user>@<server-hostname>`), which does not match the configured `from` domain. SPF authenticates that hostname rather than the `From:` domain, and no DKIM signature is aligned to the `From:` domain, so the message fails DMARC alignment. Same mechanism as phpmailer/phpmailer#2298.

## Change

Add an opt-in boolean mailer option `set_envelope_from`, defaulting to `false`. With the default, behavior is unchanged, so no existing configuration is affected. When set to `true`, the internal mailer passes `-f<from>` to sendmail as the envelope sender, letting outgoing mail pass SPF and DKIM alignment for DMARC.

The `from` address is already validated with `FILTER_VALIDATE_EMAIL` in `Mailer::setFrom()`. I still wrap it in `escapeshellarg()` before it reaches `mail()`'s `additional_params`, as defense in depth, given the shell-injection history of that argument (CVE-2016-10033).

## Notes

- Applies only to `library='internal'`, `method='mail'`. The PHPMailer path already lets you set the sender.
- On MTAs where the web or cron user is not a trusted sendmail user, enabling this can add an `X-Warning` header. I documented that next to the option in `config/conf.sample.php`.

## Testing

- `php -l` clean on both changed files.
- On my own instance I set `set_envelope_from => true` and sent a summary through an external authentication verifier. The message went out with the envelope sender matching the configured `from` (`smtp.mailfrom=dmarc@rjn.network`), giving `spf=pass` and `dkim=pass` with `header.d` matching `From:`. With the option left at its `false` default, the envelope and behavior are unchanged.
